### PR TITLE
Handle unused results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "minus"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Arijit Dey <arijid79@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
-documentation = "https://docs.rs/minus/1.0.0/minus"
+documentation = "https://docs.rs/minus"
 repository = "https://github.com/arijit79/minus"
 description = "An asynchronous paging library for Rust"
 keywords = ["pager", "asynchronous", "dynamic", "less", "more"]

--- a/examples/dyn_async_std.rs
+++ b/examples/dyn_async_std.rs
@@ -1,22 +1,28 @@
 use async_std::task::sleep;
 use futures::join;
-use minus::*;
+
 use std::fmt::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = Arc::new(Mutex::new(String::new()));
+
     let increment = async {
         let mut counter: u8 = 0;
         while counter <= 30 {
             let mut output = output.lock().unwrap();
-            let _ = writeln!(output, "{}", counter.to_string());
+            writeln!(output, "{}", counter.to_string())?;
             counter += 1;
             drop(output);
             sleep(Duration::from_millis(100)).await;
         }
+        Result::<_, std::fmt::Error>::Ok(())
     };
-    join!(async_std_updating(output.clone()), increment);
+
+    let (res1, res2) = join!(minus::async_std_updating(output.clone()), increment);
+    res1?;
+    res2?;
+    Ok(())
 }

--- a/examples/dyn_tokio.rs
+++ b/examples/dyn_tokio.rs
@@ -1,22 +1,28 @@
 use futures::join;
-use minus::*;
+use tokio::time::sleep;
+
 use std::fmt::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::time::sleep;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = Arc::new(Mutex::new(String::new()));
+
     let increment = async {
         let mut counter: u8 = 0;
         while counter <= 30 {
             let mut output = output.lock().unwrap();
-            let _ = writeln!(output, "{}", counter.to_string());
+            writeln!(output, "{}", counter.to_string())?;
             counter += 1;
             drop(output);
             sleep(Duration::from_millis(100)).await;
         }
+        Result::<_, std::fmt::Error>::Ok(())
     };
-    join!(tokio_updating(output.clone()), increment);
+
+    let (res1, res2) = join!(minus::tokio_updating(output.clone()), increment);
+    res1?;
+    res2?;
+    Ok(())
 }

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -1,9 +1,12 @@
 use std::fmt::Write;
 
-fn main() -> minus::Result {
+fn main() -> minus::Result<(), Box<dyn std::error::Error>> {
     let mut output = String::new();
+
     for i in 1..=30 {
-        let _ = writeln!(output, "{}", i);
+        writeln!(output, "{}", i)?;
     }
-    minus::page_all(&output)
+
+    minus::page_all(&output)?;
+    Ok(())
 }

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -1,9 +1,9 @@
 use std::fmt::Write;
 
-fn main() {
+fn main() -> minus::Result {
     let mut output = String::new();
     for i in 1..=30 {
         let _ = writeln!(output, "{}", i);
     }
-    minus::page_all(&output);
+    minus::page_all(&output)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,23 +12,23 @@ pub type Result<T = (), E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub enum Error {
     /// The error is an IO one, for example locking `stdout` failed.
-    IoError(io::Error),
+    Io(io::Error),
     /// An operation on the terminal failed, for example resizing it.
-    TermError(TermError),
+    Term(TermError),
     /// The task panicked or was cancelled.
     ///
     /// Gated on the `tokio_lib` feature.
     #[cfg(feature = "tokio_lib")]
-    JoinError(tokio::task::JoinError),
+    Join(tokio::task::JoinError),
 }
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::IoError(e) => Some(e),
-            Self::TermError(e) => e.source(),
+            Self::Io(e) => Some(e),
+            Self::Term(e) => e.source(),
             #[cfg(feature = "tokio_lib")]
-            Self::JoinError(e) => Some(e),
+            Self::Join(e) => Some(e),
         }
     }
 }
@@ -36,10 +36,10 @@ impl std::error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::IoError(e) => write!(fmt, "IO-error occurred: {}", e),
-            Self::TermError(e) => write!(fmt, "Operation on terminal failed: {}", e),
+            Self::Io(e) => write!(fmt, "IO-error occurred: {}", e),
+            Self::Term(e) => write!(fmt, "Operation on terminal failed: {}", e),
             #[cfg(feature = "tokio_lib")]
-            Self::JoinError(e) => write!(fmt, "Join error: {}", e),
+            Self::Join(e) => write!(fmt, "Join error: {}", e),
         }
     }
 }
@@ -78,13 +78,13 @@ macro_rules! impl_from {
     };
 }
 
-impl_from!(::std::io::Error, crate::Error::IoError);
-impl_from!(crate::TermError, crate::Error::TermError);
+impl_from!(::std::io::Error, crate::Error::Io);
+impl_from!(crate::TermError, crate::Error::Term);
 #[cfg(feature = "tokio_lib")]
-impl_from!(::tokio::task::JoinError, crate::Error::JoinError);
+impl_from!(::tokio::task::JoinError, crate::Error::Join);
 
 impl From<crossterm::ErrorKind> for crate::Error {
     fn from(e: crossterm::ErrorKind) -> Self {
-        Self::TermError(TermError(e))
+        Self::Term(TermError(e))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,80 @@
+//! See [`Error`] and [`Result`].
+use crossterm;
+
+use std::fmt;
+use std::io;
+
+/// Type alias for easier use of errors produced by [`minus`](crate).
+pub type Result<T = (), E = Error> = std::result::Result<T, E>;
+
+/// Global error type for [`minus`](crate).
+///
+/// You can get more informations about this error by calling
+/// [`source`](std::error::Error::source) on it.
+#[derive(Debug)]
+pub enum Error {
+    /// The error is an IO one, for example locking `stdout` failed.
+    IoError(io::Error),
+    /// An operation on the terminal failed, for example resizing it.
+    TermError(TermError),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::IoError(e) => Some(e),
+            Self::TermError(e) => e.source(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IoError(e) => write!(fmt, "IO-error occurred: {}", e),
+            Self::TermError(e) => write!(fmt, "Operation on terminal failed: {}", e),
+        }
+    }
+}
+
+/// An operation on the terminal failed, for example resizing it.
+///
+/// You can get more informations about this error by calling
+/// [`source`](std::error::Error::source) on it.
+#[derive(Debug)]
+pub struct TermError(
+    // This member is private to avoid leaking the crossterm error type up the
+    // dependency chain.
+    crossterm::ErrorKind,
+);
+
+impl std::error::Error for TermError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl fmt::Display for TermError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
+}
+
+macro_rules! impl_from {
+    ($from:path, $to:expr) => {
+        impl From<$from> for crate::Error {
+            fn from(e: $from) -> Self {
+                $to(e)
+            }
+        }
+    };
+}
+
+impl_from!(io::Error, Error::IoError);
+impl_from!(TermError, Error::TermError);
+
+impl From<crossterm::ErrorKind> for crate::Error {
+    fn from(e: crossterm::ErrorKind) -> Self {
+        Self::TermError(TermError(e))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
 //! See [`Error`] and [`Result`].
-use crossterm;
-
 use std::fmt;
 use std::io;
 
@@ -42,6 +40,7 @@ impl fmt::Display for Error {
 /// You can get more informations about this error by calling
 /// [`source`](std::error::Error::source) on it.
 #[derive(Debug)]
+#[allow(clippy::module_name_repetitions)]
 pub struct TermError(
     // This member is private to avoid leaking the crossterm error type up the
     // dependency chain.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,33 @@
-//! Minus is a library for creating paged output for other terminal based
-//! applications. It is threaded as well as asynchronous, which means your
-//! applications can give dynamic information. It is also cross-platform which
-//! means your applications are assured to be 100% compatible with all OSs.
+//! A fast, asynchronous terminal paging library for Rust. `minus` provides high
+//! level functionalities to easily write a pager for any terminal application. Due
+//! to the asynchronous nature of `minus`, the pager's data can be **updated**.
 //!
-//! ## Why use minus
+//! `minus` supports both [`tokio`] as well as [`async-std`] runtimes. What's more,
+//! if you only want to use `minus` for serving static output, you can simply opt
+//! out of these dynamic features, see the **Usage** section below.
 //!
-//! * Pager can run in a separate thread which is asynchronous (when using
-//! either the `async_std_lib` or `tokio_lib` feature).
-//! * Works with both tokio and `async_std`, these are individual features you
-//! can enable. So you are confirmed that you don't put bloat in your software.
-//! * Completely cross-platform.
+//! ## Why this crate ?
+//!
+//! `minus` was started by me for my work on [`pijul`]. I was unsatisfied with the
+//! existing options like `pager` and `moins`.
+//!
+//! * `pager`:
+//!     * Only provides functions to join the standard output of the current
+//!       program to the standard input of external pager like `more` or `less`.
+//!     * Due to this, to work within Windows, the external pagers need to be
+//!       packaged along with the executable.
+//!
+//! * `moins`:
+//!     * The output could only be defined once and for all. It is not asynchronous
+//!       and does not support updating.
+//!
+//! [`tokio`]: https://crates.io/crates/tokio
+//! [`async-std`]: https://crates.io/crates/async-std
 //!
 //! ## Features
 //!
-//! * `async_std_lib`: If your application uses async-std, enable this feature.
-//! * `tokio_lib`: If your application uses tokio, enable this feature.
+//! * `async_std_lib`: If your application uses [`async-std`], enable this feature.
+//! * `tokio_lib`: If your application uses [`tokio`], enable this feature.
 //! * `static_output`: Enable this if you only want to page static data.
 //!
 //! ## Examples
@@ -38,7 +51,7 @@ mod rt_wrappers;
 #[cfg(feature = "static_output")]
 mod static_pager;
 
-/// An atomically reference counted string of all output for the pager
+/// An atomically reference counted string of all output for the pager.
 pub type Lines = Arc<Mutex<String>>;
 
 pub use error::{Error, Result, TermError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,38 @@
 //! Minus is a library for creating paged output for other terminal based
 //! applications. It is threaded as well as asynchronous, which means your
-//! applications can give dynamic information. It is also cross-platform
-//! which means your applications are assured to be 100% compatible with all OSs
+//! applications can give dynamic information. It is also cross-platform which
+//! means your applications are assured to be 100% compatible with all OSs.
 //!
 //! ## Why use minus
-//! * Pager runs in a separate thread which is asynchronous
-//! * Works with both tokio and `async_std`, these are individual features you can
-//! enable. So you are confirmed that you don't put bloat in your software
-//! * Completely cross-platform
+//!
+//! * Pager can run in a separate thread which is asynchronous (when using
+//! either the `async_std_lib` or `tokio_lib` feature).
+//! * Works with both tokio and `async_std`, these are individual features you
+//! can enable. So you are confirmed that you don't put bloat in your software.
+//! * Completely cross-platform.
 //!
 //! ## Features
-//! * `async_std_lib`:- If your application uses async-std, enable this feature
-//! * `tokio_lib`:- If your application uses tokio, enable this feature
-//! * `static_output`: Enable this if you only want to page static data
+//!
+//! * `async_std_lib`: If your application uses async-std, enable this feature.
+//! * `tokio_lib`: If your application uses tokio, enable this feature.
+//! * `static_output`: Enable this if you only want to page static data.
 //!
 //! ## Examples
+//!
 //! See [`page_all`] for static output examples or [`async_std_updating`] and
-//! [`tokio_updating`] for examples of dynamic output generation using different runtimes
+//! [`tokio_updating`] for examples of dynamic output generation using
+//! different runtimes.
 
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
-mod utils;
 use std::sync::{Arc, Mutex};
+
+mod error;
+mod utils;
+
 #[cfg(any(feature = "tokio_lib", feature = "async_std_lib"))]
 mod rt_wrappers;
 #[cfg(feature = "static_output")]
@@ -32,6 +40,8 @@ mod static_pager;
 
 /// An atomically reference counted string of all output for the pager
 pub type Lines = Arc<Mutex<String>>;
+
+pub use error::{Error, Result};
 
 #[cfg(feature = "tokio_lib")]
 pub use rt_wrappers::tokio_updating;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod static_pager;
 /// An atomically reference counted string of all output for the pager
 pub type Lines = Arc<Mutex<String>>;
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, TermError};
 
 #[cfg(feature = "tokio_lib")]
 pub use rt_wrappers::tokio_updating;

--- a/src/rt_wrappers.rs
+++ b/src/rt_wrappers.rs
@@ -39,9 +39,9 @@ fn init(mutex: &Lines) {
         // Use .eq() here as == cannot compare MutexGuard with a normal string
         if !string.eq(&last_copy) {
             // FIXME(poliorcetics): handle unused Result.
-            let _ = draw(string.clone(), rows, &mut upper_mark.clone());
+            let _ = draw(&string, rows, &mut upper_mark);
             // Update the last copy, cloning here becaue string is inside MutexGuard
-            last_copy = string.clone();
+            last_copy = string.to_string();
         }
         // Drop the string
         drop(string);
@@ -70,24 +70,22 @@ fn init(mutex: &Lines) {
                 }) => {
                     upper_mark += 1;
                     // FIXME(poliorcetics): handle unused Result.
-                    let _ = draw(mutex.lock().unwrap().clone(), rows, &mut upper_mark);
+                    let _ = draw(&mutex.lock().unwrap(), rows, &mut upper_mark);
                 }
                 // If Up arrow is pressed, subtract 1 from the marker and update the string
                 Event::Key(KeyEvent {
                     code: KeyCode::Up,
                     modifiers: KeyModifiers::NONE,
                 }) => {
-                    if upper_mark != 0 {
-                        upper_mark -= 1;
-                    }
+                    upper_mark = upper_mark.saturating_sub(1);
                     // FIXME(poliorcetics): handle unused Result.
-                    let _ = draw(mutex.lock().unwrap().clone(), rows, &mut upper_mark);
+                    let _ = draw(&mutex.lock().unwrap(), rows, &mut upper_mark);
                 }
                 // When terminal is resized, update the rows and redraw
                 Event::Resize(_, height) => {
                     rows = height as usize;
                     // FIXME(poliorcetics): handle unused Result.
-                    let _ = draw(mutex.lock().unwrap().clone(), rows, &mut upper_mark);
+                    let _ = draw(&mutex.lock().unwrap(), rows, &mut upper_mark);
                 }
                 _ => {}
             }

--- a/src/rt_wrappers.rs
+++ b/src/rt_wrappers.rs
@@ -1,11 +1,13 @@
 use crate::utils::draw;
 use crate::Lines;
+
 use crossterm::{
     cursor::{Hide, Show},
     event::{poll, read, Event, KeyCode, KeyEvent, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+
 use std::io::{prelude::*, stdout};
 use std::time::Duration;
 
@@ -93,21 +95,24 @@ fn init(mutex: &Lines) {
     }
 }
 
-/// Run the pager inside a [`tokio task`](tokio::task)
+/// Run the pager inside a [`tokio task`](tokio::task).
 ///
-/// This function is only available when `tokio_lib` feature is enabled
-/// It takes a [`Lines`] and updates the page with new information when Lines
-/// is updated
+/// This function is only available when `tokio_lib` feature is enabled.
+/// It takes a [`Lines`] and updates the page with new information when `Lines`
+/// is updated.
 ///
-/// This function switches to the [`Alternate Screen`] of the TTY and
-/// switches to [`raw mode`]
+/// This function switches to the [`Alternate Screen`] of the TTY and switches
+/// to [`raw mode`].
+///
 /// ## Example
+///
 /// ```
-/// use std::sync::{Arc, Mutex};
 /// use futures::join;
-/// use std::fmt::Write;
-/// use std::time::Duration;
 /// use tokio::time::sleep;
+///
+/// use std::fmt::Write;
+/// use std::sync::{Arc, Mutex};
+/// use std::time::Duration;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -126,12 +131,13 @@ fn init(mutex: &Lines) {
 ///    join!(minus::tokio_updating(output.clone()), push_data);
 /// }
 /// ```
-/// **Please do note that you should never lock the output data, since this will cause
-/// the paging thread to be paused. Only borrow it when it is required and drop it
-/// if you have further asynchronous blocking code**
 ///
-/// [`Alternate Screen`]: ../crossterm/terminal/index.html#alternate-screen
-/// [`raw mode`]: ../crossterm/terminal/index.html#raw-mode
+/// **Please do note that you should never lock the output data, since this
+/// will cause the paging thread to be paused. Only borrow it when it is
+/// required and drop it if you have further asynchronous blocking code.**
+///
+/// [`Alternate Screen`]: crossterm::terminal#alternate-screen
+/// [`raw mode`]: crossterm::terminal#raw-mode
 #[cfg(feature = "tokio_lib")]
 pub async fn tokio_updating(mutex: Lines) {
     use tokio::task;
@@ -140,18 +146,21 @@ pub async fn tokio_updating(mutex: Lines) {
     });
 }
 
-/// Initialize a updating pager inside a [`async_std task`]
+/// Initialize a updating pager inside an [`async_std task`].
 ///
 /// This function is only available when `async_std_lib` feature is enabled
-/// It takes a [`Lines`] and updates the page with new information when Lines
-/// is updated
-/// This function switches to the [`Alternate Screen`] of the TTY and
-/// switches to [`raw mode`]
+/// It takes a [`Lines`] and updates the page with new information when `Lines`
+/// is updated.
+///
+/// This function switches to the [`Alternate Screen`] of the TTY and switches
+/// to [`raw mode`].
 ///
 /// ## Example
+///
 /// ```
-/// use std::sync::{Arc, Mutex};
 /// use futures::join;
+///
+/// use std::sync::{Arc, Mutex};
 /// use std::time::Duration;
 ///
 /// #[async_std::main]
@@ -170,14 +179,14 @@ pub async fn tokio_updating(mutex: Lines) {
 ///    join!(minus::async_std_updating(output.clone()), push_data);
 /// }
 /// ```
-/// **Please do note that you should never lock the output data, since this will cause
-/// the paging thread to be paused. Only borrow it when it is required and drop it
-/// if you have further asynchronous blocking code**
+///
+/// **Please do note that you should never lock the output data, since this
+/// will cause the paging thread to be paused. Only borrow it when it is
+/// required and drop it if you have further asynchronous blocking code.**
 ///
 /// [`async_std task`]: async_std::task
-/// [`Alternate Screen`]: ../crossterm/terminal/index.html#alternate-screen
-/// [`raw mode`]: ../crossterm/terminal/index.html#raw-mode
-/// [`Lines`]: Lines
+/// [`Alternate Screen`]: crossterm::terminal#alternate-screen
+/// [`raw mode`]: crossterm::terminal#raw-mode
 #[cfg(feature = "async_std_lib")]
 pub async fn async_std_updating(mutex: Lines) {
     use async_std::task;

--- a/src/rt_wrappers.rs
+++ b/src/rt_wrappers.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 fn init(mutex: &Lines) {
     // Initialize the terminal
+    // FIXME(poliorcetics): handle unused Result.
     let _ = execute!(stdout(), EnterAlternateScreen);
     let _ = enable_raw_mode();
     let _ = execute!(stdout(), Hide);

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -43,6 +43,7 @@ pub fn page_all(lines: &str) {
     }
 
     // Initialize the terminal
+    // FIXME(poliorcetics): handle unused Result.
     let _ = execute!(stdout(), EnterAlternateScreen);
     let _ = enable_raw_mode();
     let _ = execute!(stdout(), Hide);

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -1,3 +1,4 @@
+//! Static information output, see [`page_all`].
 use crate::utils::draw;
 
 use crossterm::{
@@ -9,21 +10,22 @@ use crossterm::{
 
 use std::io::{stdout, Write};
 
-/// Outputs static information
+/// Outputs static information.
 ///
-///. Once called, string passed to this function can never be changed. If you
+/// Once called, the `&str` passed to this function can never be changed. If you
 /// want dynamic information, see [`async_std_updating`] and [`tokio_updating`].
 ///
 /// [`async_std_updating`]: crate::rt_wrappers::async_std_updating
 /// [`tokio_updating`]: crate::rt_wrappers::tokio_updating
 ///
 /// ## Example
+///
 /// ```
-///     let mut output = String::new();
-///     for i in 1..=30 {
-///         let _ = writeln!(output, "{}", i);
-///     }
-///     minus::page_all(output);
+/// let mut output = String::new();
+/// for i in 1..=30 {
+///     let _ = writeln!(output, "{}", i);
+/// }
+/// minus::page_all(output);
 /// ```
 pub fn page_all(lines: &str) {
     // Get terminal rows and convert it to usize

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -22,17 +22,22 @@ use std::io::{stdout, Write};
 /// ## Errors
 ///
 /// Several operations can fail when outputting information to a terminal, see
-/// the [`Result`](crate::Resut) type.
+/// the [`Result`] type.
 ///
 /// ## Example
 ///
 /// ```
-/// fn main() -> minus::Result {
-///     let mut output = string::new();
+/// use std::fmt::Write;
+/// 
+/// fn main() -> minus::Result<(), Box<dyn std::error::Error>> {
+///     let mut output = String::new();
+/// 
 ///     for i in 1..=30 {
-///         let _ = writeln!(output, "{}", i);
+///         writeln!(output, "{}", i)?;
 ///     }
-///     minus::page_all(output)
+/// 
+///     minus::page_all(&output)?;
+///     Ok(())
 /// }
 /// ```
 pub fn page_all(lines: &str) -> Result {
@@ -108,3 +113,5 @@ pub fn page_all(lines: &str) -> Result {
         }
     }
 }
+
+

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -28,14 +28,14 @@ use std::io::{stdout, Write};
 ///
 /// ```
 /// use std::fmt::Write;
-/// 
+///
 /// fn main() -> minus::Result<(), Box<dyn std::error::Error>> {
 ///     let mut output = String::new();
-/// 
+///
 ///     for i in 1..=30 {
 ///         writeln!(output, "{}", i)?;
 ///     }
-/// 
+///
 ///     minus::page_all(&output)?;
 ///     Ok(())
 /// }
@@ -113,5 +113,3 @@ pub fn page_all(lines: &str) -> Result {
         }
     }
 }
-
-


### PR DESCRIPTION
Fix #9.

This PR will, when done, introduce **breaking changes**: a major version will have to be released to avoid breaking user code (notably `pijul`).

Those breaking changes will be caused by the function now returning a `minus::Result` type

TODO LIST:

- [x] Add an `Error` type and publicly export it.
- [x] Handle unused results in `static_pager.rs`.
- [x] Handle unused results in `rt_wrapper.rs`.
- [x] Update examples.
- [x] Mark breaking change in `Cargo.toml` by increasing major version number.