### PR TITLE
Included feature requirements for examples in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,23 @@ static_output = []
 futures = "^0.3.8"
 async-std = { version = "^1.7.0", features = ["attributes"] }
 tokio = { version = "^0.3.5", features = ["rt", "macros", "rt-multi-thread", "time"] }
+
+[[example]]
+name = "dyn_async_std"
+required-features = ["async_std_lib"]
+
+[[example]]
+name = "dyn_tokio"
+required-features = ["tokio_lib"]
+
+[[example]]
+name = "less-rs"
+required-features = ["async_std_lib"]
+
+[[example]]
+name = "static"
+required-features = ["static_output"]
+
+[[example]]
+name = "static_long"
+required-features = ["static_output"]


### PR DESCRIPTION
I thought it would be easier to run the examples when cargo lists the required feature for each example on 'cargo run --example'