### PR TITLE
Multiline search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ required-features = ["static_output"]
 [[example]]
 name = "static_long"
 required-features = ["static_output"]
+
+[[example]]
+name = "large_lines"
+required-features = ["static_output"]

--- a/examples/large_lines.rs
+++ b/examples/large_lines.rs
@@ -3,8 +3,10 @@ use std::fmt::Write;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut output = minus::Pager::new();
 
-    for i in 0..=30 {
-        writeln!(output.lines, "{}", i)?;
+    for _ in 0..30 {
+        for _ in 0..=30 {
+            output.push_str("Hello ")
+        }
     }
 
     minus::page_all(output)?;

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -1,12 +1,13 @@
-use std::fmt::Write;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut output = minus::Pager::new();
 
-    for i in 0..=30 {
-        writeln!(output.lines, "{}", i)?;
+    for _ in 0..30 {
+        for _ in 0..20 {
+            output.push_str("Hello ");
+        }
+        output.push_str('\n')
     }
-
+    // println!("{:?}", output.lines());
     minus::page_all(output)?;
     Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -95,9 +95,7 @@ pub(crate) fn static_paging(mut pager: Pager) -> Result<(), AlternateScreenPagin
                         if x.is_none() || y.is_none() {
                             continue;
                         }
-                        if usize::from(y.unwrap()) >= pager.upper_mark + rows {
-                            pager.upper_mark = y.unwrap().into();
-                        }
+                        
                         draw(&mut out, &mut pager, rows)?;
                         y = Some(
                             y.unwrap()


### PR DESCRIPTION
The initial searching implementation did not add search spanning multiple lines. This PR adds it but makes a breaking change to the API. So there will probably be a major version released. Although most of the work is done, searching while line numbers are turned on and resyncing everything whenline numbers are turned on needs to be worked on. Also comments and docs need to be written