### PR TITLE
Add ability to only engage the paging behaviour, if we have overflowed the screen rows

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,8 +61,6 @@ pub enum CleanupError {
     #[error("Failed to switch back to main screen")]
     LeaveAlternateScreen(TermError),
 
-    #[error("Couldn't determine the terminal size")]
-    TerminalSize(TermError),
 }
 
 /// Errors that can happen while running

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,9 @@ pub enum CleanupError {
 
     #[error("Failed to switch back to main screen")]
     LeaveAlternateScreen(TermError),
+
+    #[error("Couldn't determine the terminal size")]
+    TerminalSize(TermError),
 }
 
 /// Errors that can happen while running

--- a/src/init.rs
+++ b/src/init.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 pub(crate) fn static_paging(mut pager: Pager) -> Result<(), AlternateScreenPagingError> {
     // Setup terminal
     let mut out = io::stdout();
-    let mut rows = setup(&out, false)?;
+    let mut rows = setup(&out, false, true)?;
     #[allow(unused_assignments)]
     let mut redraw = true;
 
@@ -52,7 +52,7 @@ pub(crate) fn static_paging(mut pager: Pager) -> Result<(), AlternateScreenPagin
             // Update any data that may have changed
             #[allow(clippy::clippy::match_same_arms)]
             match input {
-                Some(InputEvent::Exit) => return Ok(cleanup(out, &pager.exit_strategy, &pager)?),
+                Some(InputEvent::Exit) => return Ok(cleanup(out, &pager.exit_strategy, true)?),
                 Some(InputEvent::UpdateRows(r)) => {
                     rows = r;
                     redraw = true;
@@ -159,7 +159,9 @@ pub(crate) async fn dynamic_paging(
 ) -> std::result::Result<(), AlternateScreenPagingError> {
     // Setup terminal
     let mut out = io::stdout();
-    let mut rows = setup(&out, true)?;
+    let page_if_havent_overflowed = { p.lock().await.page_if_havent_overflowed };
+    let mut rows = setup(&out, true, page_if_havent_overflowed)?;
+
     // Search related variables
     // Vector of match coordinates
     // Earch element is a (x,y) pair, where the cursor will be placed
@@ -188,6 +190,9 @@ pub(crate) async fn dynamic_paging(
         let have_overflowed = line_count > rows;
         let have_just_overflowed = (last_line_count <= rows) && have_overflowed;
 
+        if have_just_overflowed && !page_if_havent_overflowed {
+            setup(&out, true, true)?;
+        }
         if last_line_count != line_count && ((line_count < rows) || have_just_overflowed) {
             draw(&mut out, &mut guard, rows)?;
             last_line_count = line_count;
@@ -195,8 +200,8 @@ pub(crate) async fn dynamic_paging(
 
         let data_is_finished = guard.data_finished;
 
-        if data_is_finished && !guard.page_if_havent_overflowed && !have_overflowed {
-            return Ok(cleanup(out, &guard.exit_strategy, &guard)?);
+        if data_is_finished && !page_if_havent_overflowed && !have_overflowed {
+            return Ok(cleanup(out, &guard.exit_strategy, false)?);
         }
 
         drop(guard);
@@ -219,7 +224,7 @@ pub(crate) async fn dynamic_paging(
             );
             // Update any data that may have changed
             match input {
-                Some(InputEvent::Exit) => return Ok(cleanup(out, &lock.exit_strategy, &lock)?),
+                Some(InputEvent::Exit) => return Ok(cleanup(out, &lock.exit_strategy, true)?),
                 Some(InputEvent::UpdateRows(r)) => {
                     rows = r;
                     redraw = true;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,9 +27,12 @@ use crate::{
 /// ## Errors
 ///
 /// Setting up the terminal can fail, see [`SetupError`](SetupError).
-pub(crate) fn setup(stdout: &io::Stdout, dynamic: bool) -> std::result::Result<usize, SetupError> {
+pub(crate) fn setup(
+    stdout: &io::Stdout,
+    dynamic: bool,
+    setup_screen: bool,
+) -> std::result::Result<usize, SetupError> {
     let mut out = stdout.lock();
-
     // Check if the standard output is a TTY and not a file or something else but only in dynamic mode
     if dynamic {
         use crossterm::tty::IsTty;
@@ -40,16 +43,16 @@ pub(crate) fn setup(stdout: &io::Stdout, dynamic: bool) -> std::result::Result<u
             Err(SetupError::InvalidTerminal)
         }?;
     }
-
-    execute!(out, terminal::EnterAlternateScreen)
-        .map_err(|e| SetupError::AlternateScreen(e.into()))?;
-    terminal::enable_raw_mode().map_err(|e| SetupError::RawMode(e.into()))?;
-    execute!(out, cursor::Hide).map_err(|e| SetupError::HideCursor(e.into()))?;
-    execute!(out, event::EnableMouseCapture)
-        .map_err(|e| SetupError::EnableMouseCapture(e.into()))?;
-
     let (_, rows) = terminal::size().map_err(|e| SetupError::TerminalSize(e.into()))?;
 
+    if setup_screen {
+        execute!(out, terminal::EnterAlternateScreen)
+            .map_err(|e| SetupError::AlternateScreen(e.into()))?;
+        terminal::enable_raw_mode().map_err(|e| SetupError::RawMode(e.into()))?;
+        execute!(out, cursor::Hide).map_err(|e| SetupError::HideCursor(e.into()))?;
+        execute!(out, event::EnableMouseCapture)
+            .map_err(|e| SetupError::EnableMouseCapture(e.into()))?;
+    }
     Ok(rows as usize)
 }
 
@@ -65,16 +68,14 @@ pub(crate) fn setup(stdout: &io::Stdout, dynamic: bool) -> std::result::Result<u
 pub(crate) fn cleanup(
     mut out: impl io::Write,
     es: &crate::ExitStrategy,
-    pager: &Pager,
+    cleanup_screen: bool,
 ) -> std::result::Result<(), CleanupError> {
-    // Reverse order of setup.
-    execute!(out, event::DisableMouseCapture)
-        .map_err(|e| CleanupError::DisableMouseCapture(e.into()))?;
-    execute!(out, cursor::Show).map_err(|e| CleanupError::ShowCursor(e.into()))?;
-    terminal::disable_raw_mode().map_err(|e| CleanupError::DisableRawMode(e.into()))?;
-
-    let (_, rows) = terminal::size().map_err(|e| CleanupError::TerminalSize(e.into()))?;
-    if pager.page_if_havent_overflowed || pager.get_lines().lines().count() < rows as usize {
+    if cleanup_screen {
+        // Reverse order of setup.
+        execute!(out, event::DisableMouseCapture)
+            .map_err(|e| CleanupError::DisableMouseCapture(e.into()))?;
+        execute!(out, cursor::Show).map_err(|e| CleanupError::ShowCursor(e.into()))?;
+        terminal::disable_raw_mode().map_err(|e| CleanupError::DisableRawMode(e.into()))?;
         execute!(out, terminal::LeaveAlternateScreen)
             .map_err(|e| CleanupError::LeaveAlternateScreen(e.into()))?;
     }
@@ -285,7 +286,7 @@ fn draw_without_paging(
     mut pager: &mut Pager,
     rows: usize,
 ) -> io::Result<()> {
-    write!(out, "{}{}", Clear(ClearType::All), MoveTo(0, 0))?;
+    // write!(out, "{}{}", Clear(ClearType::All), MoveTo(0, 0))?;
     write_lines(out, &mut pager, rows)
 }
 


### PR DESCRIPTION
As above,

This would be nice, for inclusion into the nushell ecosystem. Otherwise the paging makes the usability feel awkward (always paging). I tried doing this on nushell side, but this makes it alot easier & I was not able to get it working in the end the other way with async et al.

This still clears the screen each draw, but doesnt output all the other stuff, unless we have overflowed.

It may make more sense to have completely separate setup & cleanup sequences for each modes and:

if we over flow & page_if_havent_overflowed  == false, rerun setup which will clear the screen etc.
run different cleanup routines if we have overflowed, or not.

This also adds a data_finished() method, which flags to the system that data is no longer coming. This only makes sense when page_if_havent_overflowed == false. if we have finished data, and havent overflowed, we return out of the run loop.

There may be issues with static pager, I havent tested it yet. but it would also be good to have some tests for these functions, that test what the actual output to the screen is, if possible. might be fairly impossible with terminal emulatioin etc.

Hope this makes sense!
