### PR TITLE
Upgrade crossterm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [dependencies]
 async-std = { version = "^1.7.0", optional = true, default-features = false }
-crossterm = "0.18.2"
+crossterm = "0.19.0"
 tokio = { version = "^1.0", optional = true, features = ["rt"] }
 thiserror = "1.0.22"
 regex = { version = "^1.4", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,6 @@ pub enum CleanupError {
 
     #[error("Failed to switch back to main screen")]
     LeaveAlternateScreen(TermError),
-
 }
 
 /// Errors that can happen while running

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utilities that are used in both static and async display.
 use crossterm::{
     cursor::{self, MoveTo},
-    event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent},
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind},
     execute,
     style::Attribute,
     terminal::{self, Clear, ClearType},
@@ -156,12 +156,14 @@ pub(crate) fn handle_input(
         }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
 
         // Mouse scroll up/down
-        Event::Mouse(MouseEvent::ScrollUp(_, _, _)) => {
-            Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(5)))
-        }
-        Event::Mouse(MouseEvent::ScrollDown(_, _, _)) => {
-            Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(5)))
-        }
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            ..
+        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(5))),
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            ..
+        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(5))),
         // Go to top.
         Event::Key(KeyEvent {
             code: KeyCode::Char('g'),

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -454,7 +454,12 @@ fn input_handling() {
     }
 
     {
-        let ev = Event::Mouse(MouseEvent::ScrollDown(0, 0, KeyModifiers::NONE));
+        let ev = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark + 5)),
             handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
@@ -462,7 +467,12 @@ fn input_handling() {
     }
 
     {
-        let ev = Event::Mouse(MouseEvent::ScrollUp(0, 0, KeyModifiers::NONE));
+        let ev = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark - 5)),
             handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)


### PR DESCRIPTION
This upgrades to crossterm 0.19.0.

It also updates code which broke, due to different handling of ScrollUp & ScrollDown events in 0.19.0