### PR TITLE
Add exit callback

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -52,7 +52,10 @@ pub(crate) fn static_paging(mut pager: Pager) -> Result<(), AlternateScreenPagin
             // Update any data that may have changed
             #[allow(clippy::clippy::match_same_arms)]
             match input {
-                Some(InputEvent::Exit) => return Ok(cleanup(out, &pager.exit_strategy, true)?),
+                Some(InputEvent::Exit) => {
+                    pager.exit();
+                    return Ok(cleanup(out, &pager.exit_strategy, true)?);
+                }
                 Some(InputEvent::UpdateRows(r)) => {
                     rows = r;
                     redraw = true;
@@ -201,6 +204,7 @@ pub(crate) async fn dynamic_paging(
         let data_is_finished = guard.data_finished;
 
         if data_is_finished && !page_if_havent_overflowed && !have_overflowed {
+            guard.exit();
             return Ok(cleanup(out, &guard.exit_strategy, false)?);
         }
 
@@ -224,7 +228,10 @@ pub(crate) async fn dynamic_paging(
             );
             // Update any data that may have changed
             match input {
-                Some(InputEvent::Exit) => return Ok(cleanup(out, &lock.exit_strategy, true)?),
+                Some(InputEvent::Exit) => {
+                    lock.exit();
+                    return Ok(cleanup(out, &lock.exit_strategy, true)?);
+                }
                 Some(InputEvent::UpdateRows(r)) => {
                     rows = r;
                     redraw = true;

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -599,3 +599,20 @@ fn input_handling() {
         );
     }
 }
+#[cfg(feature = "async_std_lib")]
+#[cfg(test)]
+mod async_std_tests {
+    use crate::Pager;
+    use std::sync::atomic::Ordering;
+    use std::sync::{atomic::AtomicBool, Arc};
+    #[test]
+    pub fn test_exit_callback() {
+        let mut pager = Pager::new();
+        let exited = Arc::new(AtomicBool::new(false));
+        let exited_within_callback = exited.clone();
+        pager.add_exit_callback(move || exited_within_callback.store(true, Ordering::Relaxed));
+        pager.exit();
+
+        assert_eq!(true, exited.load(Ordering::Relaxed));
+    }
+}


### PR DESCRIPTION
This enables running callbacks, when the user exits from minus via pressing q & what not.

This is useful (essential!) when the other async data-producing code is possibly long running, and can be used to i.e. check for an exit variable shared via Arc<AtomicBool> within the data-producing async loop, to exit early.

I can add an example, to show how this works, as it may help understanding, and also for future users of the library, as the code is a little tricky.