### PR TITLE
Add InputHandler trait, to allow client code to define custom keybindings

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -6,7 +6,7 @@
 use crate::search;
 #[cfg(feature = "search")]
 use crate::utils::SearchMode;
-use crate::utils::{cleanup, draw, handle_input, setup, InputEvent};
+use crate::utils::{cleanup, draw, setup, InputEvent};
 #[cfg(any(feature = "tokio_lib", feature = "async_std_lib"))]
 use crate::PagerMutex;
 use crate::{error::AlternateScreenPagingError, Pager};
@@ -41,7 +41,7 @@ pub(crate) fn static_paging(mut pager: Pager) -> Result<(), AlternateScreenPagin
             .map_err(|e| AlternateScreenPagingError::HandleEvent(e.into()))?
         {
             // Get the events
-            let input = handle_input(
+            let input = pager.input_handler.handle_input(
                 event::read().map_err(|e| AlternateScreenPagingError::HandleEvent(e.into()))?,
                 pager.upper_mark,
                 #[cfg(feature = "search")]
@@ -218,7 +218,7 @@ pub(crate) async fn dynamic_paging(
             let mut lock = p.lock().await;
 
             // Get the events
-            let input = handle_input(
+            let input = lock.input_handler.handle_input(
                 event::read().map_err(|e| AlternateScreenPagingError::HandleEvent(e.into()))?,
                 lock.upper_mark,
                 #[cfg(feature = "search")]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,0 +1,144 @@
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+
+use super::utils::InputEvent;
+#[cfg(feature = "search")]
+use super::utils::SearchMode;
+use crate::LineNumbers;
+
+pub trait InputHandler {
+    fn handle_input(
+        &self,
+        ev: Event,
+        upper_mark: usize,
+        #[cfg(feature = "search")] search_mode: SearchMode,
+        ln: LineNumbers,
+        rows: usize,
+    ) -> Option<InputEvent>;
+}
+
+pub struct DefaultInputHandler;
+
+impl InputHandler for DefaultInputHandler {
+    fn handle_input(
+        &self,
+        ev: Event,
+        upper_mark: usize,
+        #[cfg(feature = "search")] search_mode: SearchMode,
+        ln: LineNumbers,
+        rows: usize,
+    ) -> Option<InputEvent> {
+        match ev {
+            // Scroll up by one.
+            Event::Key(KeyEvent {
+                code: KeyCode::Up,
+                modifiers: KeyModifiers::NONE,
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('j'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
+
+            // Scroll down by one.
+            Event::Key(KeyEvent {
+                code: KeyCode::Down,
+                modifiers: KeyModifiers::NONE,
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('k'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
+
+            // Mouse scroll up/down
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                ..
+            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(5))),
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                ..
+            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(5))),
+            // Go to top.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('g'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(0)),
+            // Go to bottom.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('g'),
+                modifiers: KeyModifiers::SHIFT,
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('G'),
+                modifiers: KeyModifiers::SHIFT,
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('G'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(usize::MAX)),
+
+            // Page Up/Down
+            Event::Key(KeyEvent {
+                code: KeyCode::PageUp,
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(
+                upper_mark.saturating_sub(rows - 1),
+            )),
+            Event::Key(KeyEvent {
+                code: KeyCode::PageDown,
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::UpdateUpperMark(
+                upper_mark.saturating_add(rows - 1),
+            )),
+
+            // Resize event from the terminal.
+            Event::Resize(_, height) => Some(InputEvent::UpdateRows(height as usize)),
+            // Switch line number display.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('l'),
+                modifiers: KeyModifiers::CONTROL,
+            }) => Some(InputEvent::UpdateLineNumber(!ln)),
+            // Quit.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('q'),
+                modifiers: KeyModifiers::NONE,
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::CONTROL,
+            }) => Some(InputEvent::Exit),
+            #[cfg(feature = "search")]
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('/'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::Search(SearchMode::Forward)),
+            #[cfg(feature = "search")]
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('?'),
+                modifiers: KeyModifiers::NONE,
+            }) => Some(InputEvent::Search(SearchMode::Reverse)),
+            #[cfg(feature = "search")]
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('n'),
+                modifiers: KeyModifiers::NONE,
+            }) => {
+                if search_mode == SearchMode::Reverse {
+                    Some(InputEvent::PrevMatch)
+                } else {
+                    Some(InputEvent::NextMatch)
+                }
+            }
+            #[cfg(feature = "search")]
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('p'),
+                modifiers: KeyModifiers::NONE,
+            }) => {
+                if search_mode == SearchMode::Reverse {
+                    Some(InputEvent::NextMatch)
+                } else {
+                    Some(InputEvent::PrevMatch)
+                }
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,12 @@ mod search;
 mod static_pager;
 mod utils;
 
-use input::{DefaultInputHandler, InputHandler};
+#[cfg(feature = "search")]
+pub use utils::SearchMode;
+
+pub use utils::InputEvent;
+
+pub use input::{DefaultInputHandler, InputHandler};
 #[cfg(feature = "static_output")]
 pub use static_pager::page_all;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,16 @@
 compile_error!("Only tokio, or async_std_lib can be enabled at a time");
 
 mod error;
+mod input;
 #[cfg(any(feature = "tokio_lib", feature = "async_std_lib"))]
 mod rt_wrappers;
+// #[cfg(feature = "search")]
 mod search;
 #[cfg(feature = "static_output")]
 mod static_pager;
 mod utils;
 
+use input::{DefaultInputHandler, InputHandler};
 #[cfg(feature = "static_output")]
 pub use static_pager::page_all;
 
@@ -107,6 +110,8 @@ pub struct Pager {
     pub prompt: String,
     // has all the data been sent to the pager
     pub data_finished: bool,
+    // trait which will handle mapping crossterm input, into minus events
+    pub input_handler: Box<dyn InputHandler + Send + Sync>,
     // callbacks which will be called when we finish
     on_exit_callbacks: ExitCallbacks,
     /// The behaviour to do when user quits the program using `q` or `Ctrl+C`
@@ -140,6 +145,7 @@ impl Pager {
     /// ```
     #[must_use]
     pub fn new() -> Self {
+        let input_handler = Box::new(DefaultInputHandler {});
         Pager {
             lines: String::new(),
             line_numbers: LineNumbers::Disabled,
@@ -149,6 +155,7 @@ impl Pager {
             data_finished: false,
             on_exit_callbacks: Vec::new(),
             page_if_havent_overflowed: true,
+            input_handler,
             searchable: true,
             #[cfg(feature = "search")]
             search_term: String::new(),
@@ -242,6 +249,15 @@ impl Pager {
     #[must_use]
     pub fn set_exit_strategy(mut self, strategy: ExitStrategy) -> Self {
         self.exit_strategy = strategy;
+        self
+    }
+
+    /// Set the [`InputHandler`] that maps from crossterm input events
+    /// to minuses internal events, this allows custom keybindings
+    ///
+    #[must_use]
+    pub fn set_input_handler(mut self, input_handler: Box<dyn InputHandler + Send + Sync>) -> Self {
+        self.input_handler = input_handler;
         self
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,7 @@
 //! Utilities that are used in both static and async display.
 use crossterm::{
     cursor::{self, MoveTo},
-    event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind},
-    execute,
+    event, execute,
     style::Attribute,
     terminal::{self, Clear, ClearType},
 };
@@ -120,134 +119,6 @@ pub enum SearchMode {
     Reverse,
     /// Don;t know the current search mode
     Unknown,
-}
-
-/// Returns the input corresponding to the given event, updating the data as
-/// needed (`pager.upper_mark`, `pager.line_numbers` or nothing).
-///
-/// - `pager.upper_mark` will be (inc|dec)remented if the (`Up`|`Down`) is pressed.
-/// - `pager.line_numbers` will be inverted if `Ctrl+L` is pressed. See the `Not` implementation
-///   for [`LineNumbers`] for more information.
-pub(crate) fn handle_input(
-    ev: Event,
-    upper_mark: usize,
-    #[cfg(feature = "search")] search_mode: SearchMode,
-    ln: LineNumbers,
-    rows: usize,
-) -> Option<InputEvent> {
-    match ev {
-        // Scroll up by one.
-        Event::Key(KeyEvent {
-            code: KeyCode::Up,
-            modifiers: KeyModifiers::NONE,
-        })
-        | Event::Key(KeyEvent {
-            code: KeyCode::Char('j'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
-
-        // Scroll down by one.
-        Event::Key(KeyEvent {
-            code: KeyCode::Down,
-            modifiers: KeyModifiers::NONE,
-        })
-        | Event::Key(KeyEvent {
-            code: KeyCode::Char('k'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
-
-        // Mouse scroll up/down
-        Event::Mouse(MouseEvent {
-            kind: MouseEventKind::ScrollUp,
-            ..
-        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(5))),
-        Event::Mouse(MouseEvent {
-            kind: MouseEventKind::ScrollDown,
-            ..
-        }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(5))),
-        // Go to top.
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('g'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(0)),
-        // Go to bottom.
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('g'),
-            modifiers: KeyModifiers::SHIFT,
-        })
-        | Event::Key(KeyEvent {
-            code: KeyCode::Char('G'),
-            modifiers: KeyModifiers::SHIFT,
-        })
-        | Event::Key(KeyEvent {
-            code: KeyCode::Char('G'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(usize::MAX)),
-
-        // Page Up/Down
-        Event::Key(KeyEvent {
-            code: KeyCode::PageUp,
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(
-            upper_mark.saturating_sub(rows - 1),
-        )),
-        Event::Key(KeyEvent {
-            code: KeyCode::PageDown,
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::UpdateUpperMark(
-            upper_mark.saturating_add(rows - 1),
-        )),
-
-        // Resize event from the terminal.
-        Event::Resize(_, height) => Some(InputEvent::UpdateRows(height as usize)),
-        // Switch line number display.
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('l'),
-            modifiers: KeyModifiers::CONTROL,
-        }) => Some(InputEvent::UpdateLineNumber(!ln)),
-        // Quit.
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('q'),
-            modifiers: KeyModifiers::NONE,
-        })
-        | Event::Key(KeyEvent {
-            code: KeyCode::Char('c'),
-            modifiers: KeyModifiers::CONTROL,
-        }) => Some(InputEvent::Exit),
-        #[cfg(feature = "search")]
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('/'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::Search(SearchMode::Forward)),
-        #[cfg(feature = "search")]
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('?'),
-            modifiers: KeyModifiers::NONE,
-        }) => Some(InputEvent::Search(SearchMode::Reverse)),
-        #[cfg(feature = "search")]
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('n'),
-            modifiers: KeyModifiers::NONE,
-        }) => {
-            if search_mode == SearchMode::Reverse {
-                Some(InputEvent::PrevMatch)
-            } else {
-                Some(InputEvent::NextMatch)
-            }
-        }
-        #[cfg(feature = "search")]
-        Event::Key(KeyEvent {
-            code: KeyCode::Char('p'),
-            modifiers: KeyModifiers::NONE,
-        }) => {
-            if search_mode == SearchMode::Reverse {
-                Some(InputEvent::NextMatch)
-            } else {
-                Some(InputEvent::PrevMatch)
-            }
-        }
-        _ => None,
-    }
 }
 
 /// Draws (at most) `rows` `lines`, where the first line to display is

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -1,7 +1,12 @@
 #![allow(clippy::shadow_unrelated)]
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+
 use super::*;
 
-use crate::{LineNumbers, Pager};
+use crate::{
+    input::{DefaultInputHandler, InputHandler},
+    LineNumbers, Pager,
+};
 use std::fmt::Write;
 
 #[test]
@@ -409,6 +414,8 @@ fn input_handling() {
     let ln = LineNumbers::Enabled;
     let rows = 5;
 
+    let input_handler: Box<dyn InputHandler> = Box::new(DefaultInputHandler {});
+
     {
         let ev = Event::Key(KeyEvent {
             code: KeyCode::Down,
@@ -416,7 +423,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark + 1)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -427,7 +434,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark - 1)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -438,7 +445,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(usize::MAX)),
-            handle_input(ev, usize::MAX, SearchMode::Unknown, ln, rows),
+            input_handler.handle_input(ev, usize::MAX, SearchMode::Unknown, ln, rows),
         );
     }
 
@@ -449,7 +456,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(usize::MIN)),
-            handle_input(ev, usize::MIN, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, usize::MIN, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -462,7 +469,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark + 5)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -475,7 +482,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(upper_mark - 5)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -486,7 +493,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(0)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -498,7 +505,7 @@ fn input_handling() {
         assert_eq!(
             // rows is 5, therefore upper_mark = upper_mark - rows -1
             Some(InputEvent::UpdateUpperMark(8)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -509,7 +516,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(usize::MAX)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -520,7 +527,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(usize::MAX)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -531,7 +538,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateUpperMark(usize::MAX)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -543,7 +550,7 @@ fn input_handling() {
         assert_eq!(
             // rows is 5, therefore upper_mark = upper_mark - rows -1
             Some(InputEvent::UpdateUpperMark(16)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -551,7 +558,7 @@ fn input_handling() {
         let ev = Event::Resize(42, 35);
         assert_eq!(
             Some(InputEvent::UpdateRows(35)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -562,7 +569,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::UpdateLineNumber(!ln)),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -573,7 +580,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::Exit),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -584,7 +591,7 @@ fn input_handling() {
         });
         assert_eq!(
             Some(InputEvent::Exit),
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 
@@ -595,7 +602,7 @@ fn input_handling() {
         });
         assert_eq!(
             None,
-            handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
+            input_handler.handle_input(ev, upper_mark, SearchMode::Unknown, ln, rows)
         );
     }
 }


### PR DESCRIPTION
Add InputHandler trait which is settable on the pager struct, via set_input_handler(input_handler: Box<dyn InputHandler>)

Also add a DefaultInputHandler which handles input according to minus default, which is used by default.

The code which handles the internal minus Events, remains unchanged.