### PR TITLE
Add half screen scroll keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,23 +167,25 @@ pass the limit.
 ## End user help
 Here is some help for the end user using an application that depends on minus
 
-| Action            |   Description|
-| ----------        | -------------|
-| Ctrl+C/q          | Quit the pager|
-| Arrow Up/k        | Scroll up by one line|
-| Arrow Down/j      | Scroll down by one line|
-| Page Up           | Scroll up by entire page|
-| Page Down         | Scroll down by entire page|
-| g                 | Go to the very top of the output|
-| G                 | Go to the very bottom of the output|
-| Mouse scroll Up   | Scroll up by 5 lines|
-| Mouse scroll Down | Scroll down by 5 lines|
-| Ctrl+L            | Toggle line numbers if not forced enabled/disabled|
-| /		    | Start forward search|
-| ?                 | Start backward search|
-| Esc               | Cancel search input|
-| n		    | Go to the next search match|
-| p		    | Go to the next previous match|
+| Action            | Description                                        |
+| ----------        | -------------                                      |
+| Ctrl+C/q          | Quit the pager                                     |
+| Arrow Up/k        | Scroll up by one line                              |
+| Arrow Down/j      | Scroll down by one line                            |
+| Page Up           | Scroll up by entire page                           |
+| Page Down         | Scroll down by entire page                         |
+| Ctrl+U/u          | Scroll up by half a screen                         |
+| Ctrl+D/d          | Scroll down by half a screen                       |
+| g                 | Go to the very top of the output                   |
+| G                 | Go to the very bottom of the output                |
+| Mouse scroll Up   | Scroll up by 5 lines                               |
+| Mouse scroll Down | Scroll down by 5 lines                             |
+| Ctrl+L            | Toggle line numbers if not forced enabled/disabled |
+| /                 | Start forward search                               |
+| ?                 | Start backward search                              |
+| Esc               | Cancel search input                                |
+| n                 | Go to the next search match                        |
+| p                 | Go to the next previous match                      |
 
 ## Contributing
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -82,23 +82,19 @@ impl InputHandler for DefaultInputHandler {
         match ev {
             // Scroll up by one.
             Event::Key(KeyEvent {
-                code: KeyCode::Up,
+                code,
                 modifiers: KeyModifiers::NONE,
-            })
-            | Event::Key(KeyEvent {
-                code: KeyCode::Char('k'),
-                modifiers: KeyModifiers::NONE,
-            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
+            }) if code == KeyCode::Up || code == KeyCode::Char('k') => {
+                Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1)))
+            }
 
             // Scroll down by one.
             Event::Key(KeyEvent {
-                code: KeyCode::Down,
+                code,
                 modifiers: KeyModifiers::NONE,
-            })
-            | Event::Key(KeyEvent {
-                code: KeyCode::Char('j'),
-                modifiers: KeyModifiers::NONE,
-            }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
+            }) if code == KeyCode::Down || code == KeyCode::Char('j') => {
+                Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1)))
+            }
 
             // Scroll up by half screen height.
             Event::Key(KeyEvent {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -83,7 +83,7 @@ impl InputHandler for DefaultInputHandler {
                 modifiers: KeyModifiers::NONE,
             })
             | Event::Key(KeyEvent {
-                code: KeyCode::Char('j'),
+                code: KeyCode::Char('k'),
                 modifiers: KeyModifiers::NONE,
             }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
 
@@ -93,7 +93,7 @@ impl InputHandler for DefaultInputHandler {
                 modifiers: KeyModifiers::NONE,
             })
             | Event::Key(KeyEvent {
-                code: KeyCode::Char('k'),
+                code: KeyCode::Char('j'),
                 modifiers: KeyModifiers::NONE,
             }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,4 +1,7 @@
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use crossterm::{
+    event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind},
+    terminal,
+};
 
 use super::utils::InputEvent;
 #[cfg(feature = "search")]
@@ -96,6 +99,27 @@ impl InputHandler for DefaultInputHandler {
                 code: KeyCode::Char('j'),
                 modifiers: KeyModifiers::NONE,
             }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
+
+            // Scroll up by half screen height.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('u'),
+                modifiers,
+            }) if modifiers == KeyModifiers::CONTROL || modifiers == KeyModifiers::NONE => {
+                let half_screen = (terminal::size().ok()?.1 / 2) as usize;
+                Some(InputEvent::UpdateUpperMark(
+                    upper_mark.saturating_sub(half_screen),
+                ))
+            }
+            // Scroll down by half screen height.
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('d'),
+                modifiers,
+            }) if modifiers == KeyModifiers::CONTROL || modifiers == KeyModifiers::NONE => {
+                let half_screen = (terminal::size().ok()?.1 / 2) as usize;
+                Some(InputEvent::UpdateUpperMark(
+                    upper_mark.saturating_add(half_screen),
+                ))
+            }
 
             // Mouse scroll up/down
             Event::Mouse(MouseEvent {


### PR DESCRIPTION
* Fixed keys j/k behaving in reverse
* Added half screen scrolling with behaviour similar to vim/less; from vim docs:
 
 ```
                             *CTRL-U*
 CTRL-U          Scroll window Upwards in the buffer.  The number of
             lines comes from the 'scroll' option (default: half a
             screen).  If [count] given, first set the 'scroll'
             option to [count].  The cursor is moved the same
             number of lines up in the file (if possible; when
             lines wrap and when hitting the end of the file there
             may be a difference).  When the cursor is on the first
             line of the buffer nothing happens and a beep is
             produced.  See also 'startofline' option.
             {difference from vi: Vim scrolls 'scroll' screen
             lines, instead of file lines; makes a difference when
             lines wrap}
 ```
 
 ```
                             *CTRL-D*
 CTRL-D          Scroll window Downwards in the buffer.  The number of
             lines comes from the 'scroll' option (default: half a
             screen).  If [count] given, first set 'scroll' option
             to [count].  The cursor is moved the same number of
             lines down in the file (if possible; when lines wrap
             and when hitting the end of the file there may be a
             difference).  When the cursor is on the last line of
             the buffer nothing happens and a beep is produced.
             See also 'startofline' option.
             {difference from vi: Vim scrolls 'scroll' screen
             lines, instead of file lines; makes a difference when
             lines wrap}
 ```

