### PR TITLE
Fix set_page_if_havent_overflowed for static pager

### DIFF
--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -78,7 +78,7 @@ pub fn page_all(mut p: Pager) -> Result<(), PageAllError> {
         let rows = rows as usize;
 
         // If the number of lines in the output is less than the number of rows
-        if rows > line_count {
+        if !p.page_if_havent_overflowed && rows > line_count {
             let mut out = stdout.lock();
             utils::write_lines(&mut out, &mut p, line_count)?;
             out.flush()?;


### PR DESCRIPTION
Hi! Thanks for creating minus, such a great library!

Previously, setting `Pager.set_page_if_havent_overflowed(true)` had no effect if paging static output, due to an if condition in `static_pager.rs` which did not consider the setting. This commit makes this setting behave as expected when using a static reader.

As this commit only changes code so that it conforms to the documented behaviour, IMO this should only require a patch bump to the version :)

## Reproducible Example
```rust
use minus::{page_all, Pager};

let p = Pager::new()
    .set_page_if_havent_overflowed(true)
    .set_text("Some short text");
page_all(p).unwrap();
```

**Previous behaviour**: "Some short text" is printed to stdout, with no paging.

**New behaviour in this commit**: "Some short text" is paged using minus.

Cheers!