### PR TITLE
Fix u16 overflow when paging > u16::get_max() lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub struct Pager {
     search_mode: SearchMode,
     // Lines where searches have a match
     #[cfg(feature = "search")]
-    pub(crate) search_idx: Vec<u16>,
+    pub(crate) search_idx: Vec<usize>,
     // Rows of the terminal
     pub(crate) rows: usize,
     // Columns of the terminal

--- a/src/search.rs
+++ b/src/search.rs
@@ -97,13 +97,13 @@ pub(crate) fn fetch_input(
 #[cfg(feature = "search")]
 pub(crate) fn set_match_indices(pager: &mut Pager) {
     let pattern = pager.search_term.as_ref().unwrap();
-    let mut coordinates: Vec<u16> = Vec::new();
+    let mut coordinates: Vec<usize> = Vec::new();
 
     // Get all the lines in wrapping, check if they have a match and put their line numbers if they
     // do
     for (idx, line) in pager.get_flattened_lines().enumerate() {
         if pattern.is_match(&(*line).to_string()) {
-            coordinates.push(u16::try_from(idx).unwrap());
+            coordinates.push(idx);
         }
     }
     pager.search_idx = coordinates;


### PR DESCRIPTION
This fixes issue #50 and passes all tests when run with `cargo test --release --all-features`.