### PR TITLE
Further improve performance, mainly in `Pager::push_str`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,21 +394,15 @@ impl Pager {
         // if the text we have saved currently ends with a newline,
         // we want the formatted_text vector to append the line instead of
         // trying to add it to the last item
-        let newline = self.lines.ends_with('\n') || self.lines.ends_with("\n\r");
+        let newline = self.lines.ends_with('\n');
 
         // find the number of trailing whitespace characters currently on self.lines
-        let mut ending_whitespace = String::new();
-
-        // but if there's a newline, don't even check 'cause we know there's no trailing whitespace
-        if !newline {
-            for c in self.lines.chars().rev() {
-                if c.is_whitespace() && c != '\n' {
-                    ending_whitespace.push(c);
-                } else {
-                    break;
-                }
-            }
-        }
+        let ending_whitespace = self
+            .lines
+            .chars()
+            .rev()
+            .take_while(|c| c.is_whitespace() && *c != '\n')
+            .collect::<String>();
 
         // push the text to lines
         self.lines.push_str(&text);


### PR DESCRIPTION
To further improve performance, this does 3 things:
1. Adds more logic to `Pager::push_str` so that, instead of re-formatting everything when something new is pushed, it only re-formats and pushes what needs to be re-formatted.
2. Removes `Pager.wrap_lines` and `Pager.lines` and adds a new field (also called `lines`), that contains the entire text of what is shown on the screen, completely unformatted.
3. Moves the formatting logic that used to only be in `format_lines` into a new method, `Pager::formatted_line` so that both `push_str` and `format_lines` can access that logic when needed.
4. Removes an unnecessary vector clone in `format_lines` (it would clone `wrap_lines`, then clone each line of that when re-wrapping it. This now takes an iterator of `self.lines` and clones each line individually, removing the unnecessary initial clone).
5. Adds a few more tests to catch issues I ran into while implementing this, and fixes other tests that relied on `lines` and `wrap_lines`.

This also implements the changes I suggested for `push_str` [here](https://github.com/arijit79/minus/issues/53#issuecomment-971869060), where it does not wait for a newline when flushing. If you look it over and decide it's still not what you'd like for this library, I can modify it to behave as it used to. 

I'm aware this is a lot of code, but it's all nearly all interrelated and works together. I feel that I commented the new additions fairly well, but if you have any questions about any of it or would like more documentation or explanations, please let me know and I'd be more than happy to provide them.

I would also like to request that you check the logic in the tests that I added &mdash;  they all pass and I feel confident they all are asserting what should be asserted, but I think it would be smart for you to look over them just in case.