### PR TITLE
dynamic_paging: Fix missing doc(...) flag

### DIFF
--- a/src/dynamic_pager.rs
+++ b/src/dynamic_pager.rs
@@ -13,7 +13,7 @@ use crate::Pager;
 ///
 /// # Errors
 /// The function will return with an error if it encounters a error during paging.
-#[cfg_attr(docsrs, cfg(feature = "dynamic_output"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "dynamic_output")))]
 pub fn dynamic_paging(pager: Pager) -> Result<(), MinusError> {
     assert!(init::RUNMODE.set(init::RunMode::Dynamic).is_ok(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
     init::init_core(pager)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl Pager {
     /// pager.set_run_no_overflow(true).expect("Failed to send data to the pager");
     /// ```
     #[cfg(feature = "static_output")]
-    #[cfg_attr(docsrs, cfg(feature = "static_output"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "static_output")))]
     pub fn set_run_no_overflow(&self, val: bool) -> Result<(), MinusError> {
         Ok(self.tx.send(Event::SetRunNoOverflow(val))?)
     }


### PR DESCRIPTION
This PR fixes missing feature docs from some functions like `dynamic_paging` and `set_tun_no_overflow`.

This did not work because it missed the `doc(...)` in `cfg_attr(docsrs, ...)` attribute. 