### PR TITLE
Fix issue where search may not jump to the first match if it contains ANSI escapes

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -65,9 +65,12 @@ pub fn handle_event(
                 let regex = regex::Regex::new(&string);
                 if let Ok(r) = regex {
                     p.search_term = Some(r);
-                    // Prepare a index where search matches are found
-                    // and set it to pager.search_idx
-                    search::set_match_indices(p);
+
+                    // For some reason, the pager won't automatically move to the next match
+                    // unless we format lines here. that also, though, finds the search indices
+                    // for us, so we don't need to manually call that
+                    p.format_lines();
+
                     // Move to
                     search::next_match(p);
                 } else {
@@ -76,9 +79,10 @@ pub fn handle_event(
                         "Invalid regular expression. Press Enter",
                         p.cols,
                     ));
+
+                    p.format_lines();
                 }
             }
-            p.format_lines();
         }
         #[cfg(feature = "search")]
         Event::UserInput(InputEvent::NextMatch) if p.search_term.is_some() => {


### PR DESCRIPTION
I'm going to be completely honest, I don't fully understand why this issue happens or why this code, specifically, fixes it. But if we search for a term (say, `hello there`), and the first match contains an ANSI escape code (e.g. `hello \x1b[1mthere`), the pager won't automatically jump to the first match after you hit enter on the search. But, with this fix of formatting lines before setting the search indices, it will. If you'd like a reproducible example to show my point, I'd be happy to make one.