### PR TITLE
Fix line numbers and search related bugs

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -65,9 +65,12 @@ pub fn handle_event(
                 let regex = regex::Regex::new(&string);
                 if let Ok(r) = regex {
                     p.search_term = Some(r);
-                    // Prepare a index where search matches are found
-                    // and set it to pager.search_idx
-                    search::set_match_indices(p);
+
+                    // For some reason, the pager won't automatically move to the next match
+                    // unless we format lines here. that also, though, finds the search indices
+                    // for us, so we don't need to manually call that
+                    p.format_lines();
+
                     // Move to
                     search::next_match(p);
                 } else {
@@ -76,9 +79,10 @@ pub fn handle_event(
                         "Invalid regular expression. Press Enter",
                         p.cols,
                     ));
+
+                    p.format_lines();
                 }
             }
-            p.format_lines();
         }
         #[cfg(feature = "search")]
         Event::UserInput(InputEvent::NextMatch) if p.search_term.is_some() => {

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -103,7 +103,7 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceeding index
             p.search_mark = p.search_mark.saturating_sub(1);
-            let y = p.search_idx[p.search_mark];
+            let y = *p.search_idx.iter().nth(p.search_mark).unwrap();
             // If the index is less than or equal to the upper_mark, then set y to the new upper_mark
             if y < p.upper_mark {
                 p.upper_mark = y;

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -66,12 +66,10 @@ pub fn handle_event(
                 if let Ok(r) = regex {
                     p.search_term = Some(r);
 
-                    // For some reason, the pager won't automatically move to the next match
-                    // unless we format lines here. that also, though, finds the search indices
-                    // for us, so we don't need to manually call that
+                    // Format the lines, this will automatically generate the PagerState.search_idx
                     p.format_lines();
 
-                    // Move to
+                    // Move to next search match after the current upper_mark
                     search::next_match(p);
                 } else {
                     // Send invalid regex message at the prompt if invalid regex is given

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -224,13 +224,7 @@ fn start_reactor(
                         // This woll be equal to 3 as available rows will be 3
                         // If in the above example only 2 lines are needed to be added, this will be equal to 2
                         let num_appendable = fmt_text.len().min(available_rows);
-                        fmt_text
-                            .iter()
-                            .take(num_appendable)
-                            .try_for_each(|row| -> Result<(), MinusError> {
-                                    write!(out, "{}", row)?;
-                                Ok(())
-                            })?;
+                        write!(out, "{}", fmt_text[0..num_appendable].join("\n\r"))?;
                         out.flush()?;
                     }
                     // Append the formatted string to PagerState::formatted_lines vec

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -197,7 +197,7 @@ fn start_reactor(
                 Ok(Event::AppendData(text)) => {
                     let mut p = ps.lock().unwrap();
                     // Make the string that nneds to be appended
-                    let (mut fmt_text, num_unterminated) = p.make_append_str(&text);
+                    let (fmt_text, num_unterminated) = p.make_append_str(&text);
 
                     if p.num_lines() < p.rows {
                         let mut out = out.borrow_mut();
@@ -234,15 +234,7 @@ fn start_reactor(
                         out.flush()?;
                     }
                     // Append the formatted string to PagerState::formatted_lines vec
-                    if num_unterminated != 0 {
-                        p.unterminated = num_unterminated;
-                        p.formatted_lines.append(&mut fmt_text);
-                    } else if num_unterminated == 0 && p.unterminated != 0 {
-                        p.formatted_lines =
-                            p.formatted_lines[0..p.formatted_lines.len() - p.unterminated].to_vec();
-                        p.formatted_lines.append(&mut fmt_text);
-                        p.unterminated = 0;
-                    }
+                    p.append_str_on_unterminated(fmt_text, num_unterminated);
                 }
                 Ok(ev) => {
                     let mut p = ps.lock().unwrap();

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -220,6 +220,8 @@ pub fn next_match(ps: &mut PagerState) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::{highlight_line_matches, next_match, INVERT, NORMAL};
     use crate::PagerState;
     use crossterm::style::Attribute;
@@ -234,7 +236,7 @@ mod tests {
         let mut pager = PagerState::new().unwrap();
         pager.search_mark = 0;
         // A sample index for mocking actual search index matches
-        pager.search_idx = vec![2, 10, 15, 17, 50];
+        pager.search_idx = BTreeSet::from([2, 10, 15, 17, 50]);
         for i in &pager.search_idx.clone() {
             next_match(&mut pager);
             assert_eq!(pager.upper_mark, *i as usize);

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -145,13 +145,16 @@ pub fn set_match_indices(pager: &mut PagerState) {
 }
 
 /// Highlights the search match
-pub fn highlight_line_matches(line: &str, query: &regex::Regex) -> String {
+///
+/// The first return value returns the line that has all the search matches highlighted
+/// The second tells whether a search match was actually found
+pub fn highlight_line_matches(line: &str, query: &regex::Regex) -> (String, bool) {
     // Remove all ansi escapes so we can look through it as if it had none
     let stripped_str = ANSI_REGEX.replace_all(line, "");
 
     // if it doesn't match, don't even try. Just return.
     if !query.is_match(&stripped_str) {
-        return line.to_string();
+        return (line.to_string(), false);
     }
 
     // sum_width is used to calculate the total width of the ansi escapes
@@ -219,14 +222,13 @@ pub fn highlight_line_matches(line: &str, query: &regex::Regex) -> String {
         inserted_escs_len += esc.1.len();
     }
 
-    inverted
+    (inverted, true)
 }
 
 /// Set [`PagerState::search_mark`] to move to the next match
 ///
 /// This function will continue looping untill it finds a match that is after the
 /// [`PagerState::upper_mark`]
-#[cfg(feature = "search")]
 pub fn next_match(ps: &mut PagerState) {
     // Loop until we find a match, that's after the upper_mark
     //

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -206,7 +206,7 @@ pub fn next_match(ps: &mut PagerState) {
     // Loop until we find a match, that's after the upper_mark
     //
     // Get match at the given mark
-    while let Some(y) = ps.search_idx.get(ps.search_mark) {
+    while let Some(y) = ps.search_idx.iter().nth(ps.search_mark) {
         // If it's above upper_mark, continue for the next match
         if *y < ps.upper_mark {
             ps.search_mark += 1;
@@ -220,7 +220,7 @@ pub fn next_match(ps: &mut PagerState) {
 
 #[cfg(test)]
 mod tests {
-    use super::{highlight_line_matches, next_match,  INVERT, NORMAL};
+    use super::{highlight_line_matches, next_match, INVERT, NORMAL};
     use crate::PagerState;
     use crossterm::style::Attribute;
     use regex::Regex;
@@ -296,7 +296,10 @@ eros.",
     fn esc_end_in_match() {
         let orig = format!("this {}is a te{}st", ESC, NONE);
         let res = highlight_line_matches(&orig, &Regex::new("test").unwrap());
-        assert_eq!(res.0, format!("this {}is a {}test{}", ESC, *INVERT, *NORMAL));
+        assert_eq!(
+            res.0,
+            format!("this {}is a {}test{}", ESC, *INVERT, *NORMAL)
+        );
     }
 
     #[test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -218,6 +218,7 @@ pub fn next_match(ps: &mut PagerState) {
     }
 }
 
+#[allow(clippy::trivial_regex)]
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,7 +846,6 @@ impl PagerState {
                 fmt_text_len
             },
         )
-
     }
 
     /// Conditionally appends to [`self.formatted_lines`] or changes the last unterminated rows of
@@ -859,8 +858,9 @@ impl PagerState {
         mut fmt_line: Vec<String>,
         num_unterminated: usize,
     ) {
-        if num_unterminated != 0 || (num_unterminated == 0 && self.unterminated != 0) {
-            self.formatted_lines.truncate(self.formatted_lines.len() - self.unterminated);
+        if num_unterminated != 0 || self.unterminated != 0 {
+            self.formatted_lines
+                .truncate(self.formatted_lines.len() - self.unterminated);
         }
         self.formatted_lines.append(&mut fmt_line);
         self.unterminated = num_unterminated;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,6 @@ impl PagerState {
             self.lines.lines().last().unwrap_or_default().to_string()
         };
 
-
         // This will get filled if there is an ongoing search. We just need to append it to
         // self.search_idx at the end
         #[cfg(feature = "search")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,6 +103,38 @@ mod pager_append_str {
     }
 
     #[test]
+    fn appendstr_with_newlines() {
+        const LINES: [&str; 3] = [
+            "this is a normal line with no newline",
+            "this is an appended line with a newline\n",
+            "and this is a third line"
+        ];
+
+        let mut ps = PagerState::new().unwrap();
+        // For the purpose of testing wrapping while appending strs
+        ps.cols = 15;
+
+        for line in LINES {
+            ps.append_str(line);
+        }
+
+        assert_eq!(
+            ps.formatted_lines,
+            vec![
+                "this is a",
+                "normal line",
+                "with no",
+                "newlinethis is",
+                "an appended",
+                "line with a",
+                "newline",
+                "and this is a",
+                "third line"
+            ]
+        );
+    }
+
+    #[test]
     fn incremental_append() {
         const LINES: [&str; 4] = [
             "this is a line",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,7 +107,7 @@ mod pager_append_str {
         const LINES: [&str; 3] = [
             "this is a normal line with no newline",
             "this is an appended line with a newline\n",
-            "and this is a third line"
+            "and this is a third line",
         ];
 
         let mut ps = PagerState::new().unwrap();


### PR DESCRIPTION
This PR fixes two high severity bugs within `minus`
- Duplicity of  line numbers on appending str
   This occurred because text takes the last line pushed into account from `PagerState::formatted_lines` which is as in the name itself formatted causing the line numbers to be displayed twice

- Pressing `n` does not takes to the next match
   This occurred because `set_match_indices`  was sort of buggy with the new implementation of appending text