### PR TITLE
Remove unnecessary refcell usage in start_reactor

### DIFF
--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -218,10 +218,10 @@ fn start_reactor(
                         // If in the above example only 2 lines are needed to be added, this will be equal to 2
                         let num_appendable = fmt_text.len().min(available_rows);
                         write!(out_lock, "{}", fmt_text[0..num_appendable].join("\n\r"))?;
+                        out_lock.flush()?;
                     }
                     // Append the formatted string to PagerState::formatted_lines vec
                     p.append_str_on_unterminated(fmt_text, num_unterminated);
-                    out_lock.flush()?;
                 }
                 Ok(ev) => {
                     let mut p = ps.lock().unwrap();

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -15,8 +15,8 @@ use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossterm::event;
 use once_cell::sync::OnceCell;
 use std::io::{stdout, Stdout};
-use std::thread;
 use std::sync::{Arc, Mutex};
+use std::thread;
 #[cfg(feature = "static_output")]
 use {super::display::write_lines, crossterm::tty::IsTty};
 


### PR DESCRIPTION
In `start_reactor` (in `src/core/init.rs`), `RefCell`s are used unnecessarily so that the match arm closures can be declared as variables. However, if we don't declare these arms as variables and instead just insert them at the end of the match arms, we don't have to use refcells to store these variables. This also allows us to lock stdout (which is also implemented in this PR), which should make paging quicker and decrease flicker when scrolling quickly.