### PR TITLE
Fix MinusError not being imported, causing doctests to fail

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ use std::string::ToString;
 
 pub use pager::Pager;
 pub use state::PagerState;
+pub use error::MinusError;
 
 /// A convenient type for `Vec<Box<dyn FnMut() + Send + Sync + 'static>>`
 pub type ExitCallbacks = Vec<Box<dyn FnMut() + Send + Sync + 'static>>;


### PR DESCRIPTION
Right now, doctests fail since `MinusError` isn't exposed in `src/lib.rs`. This exposes it, fixing the doctests.