### PR TITLE
Fix panic when changing search term

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -67,6 +67,10 @@ pub fn handle_event(
                     // Format the lines, this will automatically generate the PagerState.search_idx
                     p.format_lines();
 
+                    // Reset search mark so it won't be out of bounds if we have
+                    // less matches in this search than last time
+                    p.search_mark = 0;
+
                     // Move to next search match after the current upper_mark
                     search::next_match(p);
                 } else {
@@ -101,10 +105,11 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceeding index
             p.search_mark = p.search_mark.saturating_sub(1);
-            let y = *p.search_idx.iter().nth(p.search_mark).unwrap();
-            // If the index is less than or equal to the upper_mark, then set y to the new upper_mark
-            if y < p.upper_mark {
-                p.upper_mark = y;
+            if let Some(y) = p.search_idx.iter().nth(p.search_mark) {
+                // If the index is less than or equal to the upper_mark, then set y to the new upper_mark
+                if *y < p.upper_mark {
+                    p.upper_mark = *y;
+                }
             }
         }
         Event::AppendData(text) => p.append_str(&text),

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -203,18 +203,17 @@ pub fn highlight_line_matches(line: &str, query: &regex::Regex) -> (String, bool
 /// This function will continue looping untill it finds a match that is after the
 /// [`PagerState::upper_mark`]
 pub fn next_match(ps: &mut PagerState) {
-    // Loop until we find a match, that's after the upper_mark
-    //
-    // Get match at the given mark
-    while let Some(y) = ps.search_idx.iter().nth(ps.search_mark) {
-        // If it's above upper_mark, continue for the next match
-        if *y < ps.upper_mark {
-            ps.search_mark += 1;
-        } else {
-            // If the condition is satisfied, set it and break
-            ps.upper_mark = *y as usize;
-            break;
-        }
+    // Find the first match that's after the upper_mark, then set the mark to that match.
+    // If we can't find one, just set it to the last match
+    if let Some(nearest_idx) = ps.search_idx.iter().position(|i| *i > ps.upper_mark) {
+        ps.search_mark = nearest_idx;
+    } else {
+        ps.search_mark = ps.search_idx.len().saturating_sub(1);
+    }
+
+    // And set the upper_mark to that match so that we scroll to it
+    if let Some(idx) = ps.search_idx.iter().nth(ps.search_mark) {
+        ps.upper_mark = *idx;
     }
 }
 


### PR DESCRIPTION
Say you search for something and it has 10 matches, and you scroll down to the 10th. `pager.search_mark` would be equal to `9`. Then, you change the `search_term` to something that has only 5 matches. It will automatically call `search::next_match(p)`, which won't change anything, since `search_idx` only has 5 elements, but `search_mark` is 9. Then, if the user tries to go to the previous match, it will get `p.search_idx.iter().nth(p.search_mark).unwrap()`, which will cause a panic.

This fixes that by:
1. Resetting `p.search_mark` to 0 when you change the `search_term` so that it isn't something outside of the bounds
2. Changing `search::next_match` so that it doesn't depend on the current state of `ps.search_mark`, and instead just jumps to what is visually the next match.
3. Doesn't force-unwrap when getting the previous match so that a potential panic instead just does nothing.