### PR TITLE
Align wrapped lines correctly where line number is omitted

### DIFF
--- a/src/core/display/tests.rs
+++ b/src/core/display/tests.rs
@@ -104,7 +104,7 @@ fn short_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r      1. A line\n\r      2. Another line",
+        "\r     1. A line\n\r     2. Another line",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -118,7 +118,7 @@ fn short_with_line_numbers() {
     // The number of lines is less than 'rows' so 'upper_mark' will be 0 even
     // if we set it to 1. This is done because everything can be displayed without problems.
     assert_eq!(
-        "\r      1. A line\n\r      2. Another line",
+        "\r     1. A line\n\r     2. Another line",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -139,7 +139,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r      1. A line\n\r      2. Another line\n\r      3. Third line",
+        "\r     1. A line\n\r     2. Another line\n\r     3. Third line",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -151,7 +151,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r      2. Another line\n\r      3. Third line\n\r      4. Fourth line",
+        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -164,7 +164,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r      2. Another line\n\r      3. Third line\n\r      4. Fourth line",
+        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -192,8 +192,8 @@ fn big_line_numbers_are_padded() {
 
     // The padding should have inserted a space before the numbers that are less than 100.
     assert_eq!(
-        "\r       96. L95\n\r       97. L96\n\r       98. L97\n\r       99. L98\n\r      100. \
-         L99\n\r      101. L100\n\r      102. L101\n\r      103. L102\n\r      104. L103\n\r      105. L104",
+        "\r      96. L95\n\r      97. L96\n\r      98. L97\n\r      99. L98\n\r     100. \
+         L99\n\r     101. L100\n\r     102. L101\n\r     103. L102\n\r     104. L103\n\r     105. L104",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 95);
@@ -305,7 +305,7 @@ fn draw_short_with_line_numbers() {
     assert!(draw(&mut out, &mut pager).is_ok());
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
-        .contains("\r      1. A line\n\r      2. Another line"));
+        .contains("\r     1. A line\n\r     2. Another line"));
     assert_eq!(pager.upper_mark, 0);
 
     let mut out = Vec::with_capacity(lines.len());
@@ -317,7 +317,7 @@ fn draw_short_with_line_numbers() {
     // if we set it to 1. This is done because everything can be displayed without problems.
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
-        .contains("\r      1. A line\n\r      2. Another line"));
+        .contains("\r     1. A line\n\r     2. Another line"));
     assert_eq!(pager.upper_mark, 0);
 }
 
@@ -337,7 +337,7 @@ fn draw_long_with_line_numbers() {
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
-        .contains("\r      1. A line\n\r      2. Another line"));
+        .contains("\r     1. A line\n\r     2. Another line"));
     assert_eq!(pager.upper_mark, 0);
 
     // This ensures that asking for a position other than 0 works.
@@ -348,7 +348,7 @@ fn draw_long_with_line_numbers() {
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
-        .contains("\r      2. Another line\n\r      3. Third line"));
+        .contains("\r     2. Another line\n\r     3. Third line"));
     assert_eq!(pager.upper_mark, 1);
 
     // This test ensures that as much text as possible will be displayed, even
@@ -360,7 +360,7 @@ fn draw_long_with_line_numbers() {
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
-        .contains("\r      3. Third line\n\r      4. Fourth line"));
+        .contains("\r     3. Third line\n\r     4. Fourth line"));
     assert_eq!(pager.upper_mark, 2);
 }
 
@@ -387,10 +387,32 @@ fn draw_big_line_numbers_are_padded() {
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
         .contains(
-            "\r       96. L95\n\r       97. L96\n\r       98. L97\n\r       99. L98\n\r      100. L99\n\r      101. L100\n\r      102. L101\n\r      103. L102\n\r      104. L103",
+            "\r      96. L95\n\r      97. L96\n\r      98. L97\n\r      99. L98\n\r     100. L99\n\r     101. L100\n\r     102. L101\n\r     103. L102\n\r     104. L103",
         )
     );
     assert_eq!(pager.upper_mark, 95);
+}
+
+#[test]
+fn draw_wrapping_line_numbers() {
+    let lines = (0..3)
+        .map(|l| format!("Line {i}: This is the line who is {i}", i = l))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let mut out = Vec::new();
+    let mut pager = PagerState::new().unwrap();
+    pager.lines = lines;
+    pager.cols = 30;
+    pager.upper_mark = 2;
+    pager.line_numbers = LineNumbers::Enabled;
+    pager.format_lines();
+
+    assert!(draw(&mut out, &mut pager).is_ok());
+
+    let written = String::from_utf8(out).expect("Should have written valid UTF-8");
+    let expected = "     2. Line 1: This is the\n\r        line who is 1\n\r     3. Line 2: This is the\n\r        line who is 2";
+    assert!(written.contains(expected));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ pub enum LineNumbers {
 }
 
 impl LineNumbers {
-    const EXTRA_PADDING: u8 = 5;
+    const EXTRA_PADDING: usize = 5;
 
     /// Returns `true` if `self` can be inverted (i.e, `!self != self`), see
     /// the documentation for the variants to know if they are invertible or

--- a/src/state.rs
+++ b/src/state.rs
@@ -169,7 +169,7 @@ impl PagerState {
             //
             // We reduce this from the number of available columns as this space cannot be used for
             // actual line display when wrapping the lines
-            let padding = len_line_number + usize::from(LineNumbers::EXTRA_PADDING);
+            let padding = len_line_number + LineNumbers::EXTRA_PADDING;
             let wrapped_lines = wrap_str(line, self.cols.saturating_sub(padding + 2));
             let mut formatted_rows = Vec::with_capacity(256);
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -170,7 +170,7 @@ impl PagerState {
             // We reduce this from the number of available columns as this space cannot be used for
             // actual line display when wrapping the lines
             let padding = len_line_number + usize::from(LineNumbers::EXTRA_PADDING);
-            let wrapped_lines = wrap_str(line, self.cols.saturating_sub(padding));
+            let wrapped_lines = wrap_str(line, self.cols.saturating_sub(padding + 2));
             let mut formatted_rows = Vec::with_capacity(256);
 
             let first_line = {
@@ -190,7 +190,7 @@ impl PagerState {
 
                 if cfg!(not(test)) {
                     format!(
-                        " {bold}{number: >len$}.{reset} {row}",
+                        "{bold}{number: >len$}.{reset} {row}",
                         bold = crossterm::style::Attribute::Bold,
                         number = idx + 1,
                         len = padding,
@@ -201,7 +201,7 @@ impl PagerState {
                     // In tests, we don't care about ANSI sequences for cool looking line numbers
                     // hence we don't include them in tests. It just makes testing more difficult
                     format!(
-                        " {number: >len$}. {row}",
+                        "{number: >len$}. {row}",
                         number = idx + 1,
                         len = padding,
                         row = row
@@ -228,7 +228,7 @@ impl PagerState {
                         }
                         row = highlighted_row;
                     }
-                    format!(" {row: >len$}", len = padding + 7, row = row)
+                    " ".repeat(padding + 2) + &row
                 })
                 .collect::<Vec<String>>();
             formatted_rows.append(&mut lines_left);


### PR DESCRIPTION
on 5.0.2, lines that were wrapped while you had line numbers enabled would look like this:
```
      1. This is a very long line yes
it is a very long line and it is a
continuation
      2. And another line starts
here
```

This fixes it to look like this:
```
      1. This is a very long line yes
         it is a very long line and it is a
         continuation
      2. And another line starts
         here
```
It also fixes tests to match this behavior and adds another test to catch if this regresses in the future.