### PR TITLE
Fix searching issues after line number wrapping changes

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -224,7 +224,7 @@ impl PagerState {
                         // If a match is found, add this line's index to PagerState::search_idx
                         let (highlighted_row, is_match) = search::highlight_line_matches(&row, st);
                         if is_match {
-                            search_idx.insert(formatted_idx + wrap_idx);
+                            search_idx.insert(formatted_idx + wrap_idx + 1);
                         }
                         row = highlighted_row;
                     }
@@ -266,7 +266,7 @@ impl PagerState {
         // expensive
         let line_count = self.lines.lines().count();
 
-        // Calculate len_line_number. This will be 2 if line_count if 50 and 3 if line_count is 100.
+        // Calculate len_line_number. This will be 2 if line_count is 50 and 3 if line_count is 100 (etc)
         let len_line_number = line_count.to_string().len();
 
         // Search idx, this will get filled by the self.formatted_line function


### PR DESCRIPTION
On 5.0.2, search doesn't work correctly when the match is in something other than the first displayed line of a matched line due to an off-by-one error. This fixes that.