### PR TITLE
README: Fix optional n not appear before keys help

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,16 +160,16 @@ Here is the list of default key/mouse actions handled by `minus`.  End-applicati
 | Action            | Description                                                      |
 |-------------------|------------------------------------------------------------------|
 | Ctrl+C/q          | Quit the pager                                                   |
-| <n>Arrow Up/k     | Scroll up by n number of line(s). If n is omitted it will be 1   |
-| <n>Arrow Down/j   | Scroll down by n number of line(s). If n is omitted it will be 1 |
+| [n] Arrow Up/k    | Scroll up by n number of line(s). If n is omitted it will be 1   |
+| [n] Arrow Down/j  | Scroll down by n number of line(s). If n is omitted it will be 1 |
 | Page Up           | Scroll up by entire page                                         |
 | Page Down         | Scroll down by entire page                                       |
-| <n>Enter          | Scroll down by n number of line(s), if n is omitted it will be 1. If there are prompt messages, this will clear them  or clear prompt messages |
+| [n] Enter         | Scroll down by n number of line(s), if n is omitted it will be 1. If there are prompt messages, this will clear them  or clear prompt messages |
 | Space             | Scroll down by one page                                          |
 | Ctrl+U/u          | Scroll up by half a screen                                       |
 | Ctrl+D/d          | Scroll down by half a screen                                     |
 | g                 | Go to the very top of the output                                 |
-| <n>G              | Go to the very bottom of the output                              |
+| [n] G             | Go to the very bottom of the output                              |
 | Mouse scroll Up   | Scroll up by 5 lines                                             |
 | Mouse scroll Down | Scroll down by 5 lines                                           |
 | Ctrl+L            | Toggle line numbers if not forced enabled/disabled               |


### PR DESCRIPTION
The README described the optional prefix of numbers before movement keys but due to the way markdown works, it was being treated as a HTML tag. This patch changes that so that it appears properly in the README. 