### PR TITLE
Actually fix me messing up the off-by-one fix

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -183,7 +183,7 @@ impl PagerState {
                     // If a match is found, add this line's index to PagerState::search_idx
                     let (highlighted_row, is_match) = search::highlight_line_matches(&row, st);
                     if is_match {
-                        search_idx.insert(formatted_idx + 1);
+                        search_idx.insert(formatted_idx);
                     }
                     row = highlighted_row;
                 }
@@ -224,7 +224,7 @@ impl PagerState {
                         // If a match is found, add this line's index to PagerState::search_idx
                         let (highlighted_row, is_match) = search::highlight_line_matches(&row, st);
                         if is_match {
-                            search_idx.insert(formatted_idx + wrap_idx + 1);
+                            search_idx.insert(formatted_idx + wrap_idx);
                         }
                         row = highlighted_row;
                     }


### PR DESCRIPTION
So sorry about this, but in #72 , I actually messed it up further since I change the wrong off-by-one thing. This actually fixes search in wrapped lines that do not have a line number, and I tested it many times to ensure that.