### PR TITLE
Introduce native input matching definition

### DIFF
--- a/src/input/definitions/keydefs.rs
+++ b/src/input/definitions/keydefs.rs
@@ -1,0 +1,268 @@
+#![allow(dead_code)]
+
+use super::{Token, MODIFIERS};
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use once_cell::sync::Lazy;
+
+static SPECIAL_KEYS: Lazy<HashMap<&str, KeyCode>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+
+    map.insert("enter", KeyCode::Enter);
+    map.insert("tab", KeyCode::Tab);
+    map.insert("backtab", KeyCode::BackTab);
+    map.insert("backspace", KeyCode::Backspace);
+    map.insert("up", KeyCode::Up);
+    map.insert("down", KeyCode::Down);
+    map.insert("right", KeyCode::Right);
+    map.insert("left", KeyCode::Left);
+    map.insert("pageup", KeyCode::PageUp);
+    map.insert("pagedown", KeyCode::PageDown);
+    map.insert("home", KeyCode::Home);
+    map.insert("end", KeyCode::End);
+    map.insert("insert", KeyCode::Insert);
+    map.insert("Delete", KeyCode::Delete);
+    map.insert("esc", KeyCode::Esc);
+    map.insert("f1", KeyCode::F(1));
+    map.insert("f2", KeyCode::F(2));
+    map.insert("f3", KeyCode::F(3));
+    map.insert("f4", KeyCode::F(4));
+    map.insert("f5", KeyCode::F(5));
+    map.insert("f6", KeyCode::F(6));
+    map.insert("f7", KeyCode::F(7));
+    map.insert("f8", KeyCode::F(8));
+    map.insert("f9", KeyCode::F(9));
+    map.insert("f10", KeyCode::F(10));
+    map.insert("f11", KeyCode::F(11));
+    map.insert("f12", KeyCode::F(12));
+    map.insert("dash", KeyCode::Char('-'));
+    map.insert("space", KeyCode::Char(' '));
+
+    map
+});
+
+struct KeySeq {
+    code: Option<KeyCode>,
+    modifiers: KeyModifiers,
+}
+
+impl Default for KeySeq {
+    fn default() -> Self {
+        Self {
+            code: None,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+}
+
+pub fn parse_key_event(text: &str) -> KeyEvent {
+    let token_list = super::parse_tokens(text);
+
+    KeySeq::gen_keyevent_from_tokenlist(&token_list, text)
+}
+
+impl KeySeq {
+    fn gen_keyevent_from_tokenlist(token_list: &[Token], text: &str) -> KeyEvent {
+        let mut ks = Self::default();
+
+        let mut token_iter = token_list.iter().peekable();
+
+        while let Some(token) = token_iter.peek() {
+            match token {
+                Token::Separator => {
+                    token_iter.next();
+                    assert!(
+                        !(token_iter.peek() == Some(&&Token::Separator)),
+                        "'{}': Multiple separators found consecutively",
+                        text
+                    );
+                }
+                Token::SingleChar(c) => {
+                    token_iter.next();
+                    if let Some(m) = MODIFIERS.get(c) {
+                        if token_iter.next() == Some(&Token::Separator) {
+                            assert!(
+                                !ks.modifiers.contains(*m),
+                                "'{}': Multiple instances of same modifier given",
+                                text
+                            );
+                            ks.modifiers.insert(*m);
+                        } else if ks.code.is_none() {
+                            ks.code = Some(KeyCode::Char(*c));
+                        } else {
+                            panic!("'{}' Invalid key input sequence given", text);
+                        }
+                    } else if ks.code.is_none() {
+                        ks.code = Some(KeyCode::Char(*c));
+                    } else {
+                        panic!("'{}': Invalid key input sequence given", text);
+                    }
+                }
+                Token::MultipleChar(c) => {
+                    let c = c.to_ascii_lowercase().to_string();
+                    SPECIAL_KEYS.get(c.as_str()).map_or_else(
+                        || panic!("'{}': Invalid key input sequence given", text),
+                        |key| {
+                            if ks.code.is_none() {
+                                ks.code = Some(*key);
+                            } else {
+                                panic!("'{}': Invalid key input sequence given", text);
+                            }
+                        },
+                    );
+                    token_iter.next();
+                }
+            }
+        }
+        KeyEvent {
+            code: ks.code.unwrap_or(KeyCode::Null),
+            modifiers: ks.modifiers,
+        }
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_parse_key_event() {
+    assert_eq!(
+        parse_key_event("up"),
+        KeyEvent {
+            code: KeyCode::Up,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("k"),
+        KeyEvent {
+            code: KeyCode::Char('k'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("j"),
+        KeyEvent {
+            code: KeyCode::Char('j'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("down"),
+        KeyEvent {
+            code: KeyCode::Down,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("down"),
+        KeyEvent {
+            code: KeyCode::Down,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("enter"),
+        KeyEvent {
+            code: KeyCode::Enter,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("c-u"),
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers: KeyModifiers::CONTROL
+        }
+    );
+    assert_eq!(
+        parse_key_event("c-d"),
+        KeyEvent {
+            code: KeyCode::Char('d'),
+            modifiers: KeyModifiers::CONTROL
+        }
+    );
+    assert_eq!(
+        parse_key_event("g"),
+        KeyEvent {
+            code: KeyCode::Char('g'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("s-g"),
+        KeyEvent {
+            code: KeyCode::Char('g'),
+            modifiers: KeyModifiers::SHIFT
+        }
+    );
+    assert_eq!(
+        parse_key_event("G"),
+        KeyEvent {
+            code: KeyCode::Char('G'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("pageup"),
+        KeyEvent {
+            code: KeyCode::PageUp,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("pagedown"),
+        KeyEvent {
+            code: KeyCode::PageDown,
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("c-l"),
+        KeyEvent {
+            code: KeyCode::Char('l'),
+            modifiers: KeyModifiers::CONTROL
+        }
+    );
+    assert_eq!(
+        parse_key_event("q"),
+        KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("c-c"),
+        KeyEvent {
+            code: KeyCode::Char('c'),
+            modifiers: KeyModifiers::CONTROL
+        }
+    );
+    assert_eq!(
+        parse_key_event("/"),
+        KeyEvent {
+            code: KeyCode::Char('/'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("?"),
+        KeyEvent {
+            code: KeyCode::Char('?'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("n"),
+        KeyEvent {
+            code: KeyCode::Char('n'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+    assert_eq!(
+        parse_key_event("p"),
+        KeyEvent {
+            code: KeyCode::Char('p'),
+            modifiers: KeyModifiers::NONE
+        }
+    );
+}

--- a/src/input/definitions/mod.rs
+++ b/src/input/definitions/mod.rs
@@ -1,0 +1,67 @@
+pub mod keydefs;
+pub mod mousedefs;
+
+use crossterm::event::KeyModifiers;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+fn parse_tokens(mut text: &str) -> Vec<Token> {
+    assert!(
+        text.chars().all(|c| c.is_ascii()),
+        "'{}': Non ascii sequence found in input sequence",
+        text
+    );
+    text = text.trim();
+    assert!(
+        text.chars().any(|c| !c.is_whitespace()),
+        "'{}': Whitespace character found in input sequence",
+        text
+    );
+
+    let mut token_list = Vec::with_capacity(text.len());
+
+    let mut chars_peek = text.chars().peekable();
+
+    let mut s = String::with_capacity(5);
+
+    let flush_s = |s: &mut String, token_list: &mut Vec<Token>| {
+        match s.len() {
+            1 => token_list.push(Token::SingleChar(s.chars().next().unwrap())),
+            2.. => token_list.push(Token::MultipleChar(s.clone())),
+            _ => {}
+        }
+        s.clear();
+    };
+
+    while let Some(chr) = chars_peek.peek() {
+        match chr {
+            '-' => {
+                flush_s(&mut s, &mut token_list);
+                token_list.push(Token::Separator);
+            }
+            c => {
+                s.push(*c);
+            }
+        }
+        chars_peek.next();
+    }
+    flush_s(&mut s, &mut token_list);
+
+    token_list
+}
+
+pub static MODIFIERS: Lazy<HashMap<char, KeyModifiers>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    map.insert('m', KeyModifiers::ALT);
+    map.insert('c', KeyModifiers::CONTROL);
+    map.insert('s', KeyModifiers::SHIFT);
+
+    map
+});
+
+#[derive(Debug, PartialEq)]
+enum Token {
+    Separator, // -
+    SingleChar(char),
+    MultipleChar(String),
+}

--- a/src/input/definitions/mousedefs.rs
+++ b/src/input/definitions/mousedefs.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+
+use super::{Token, MODIFIERS};
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use once_cell::sync::Lazy;
+
+static MOUSE_ACTIONS: Lazy<HashMap<&str, MouseEventKind>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+
+    map.insert("left:down", MouseEventKind::Down(MouseButton::Left));
+    map.insert("right:down", MouseEventKind::Down(MouseButton::Right));
+    map.insert("mid:down", MouseEventKind::Down(MouseButton::Middle));
+
+    map.insert("left:up", MouseEventKind::Up(MouseButton::Left));
+    map.insert("right:up", MouseEventKind::Up(MouseButton::Right));
+    map.insert("mid:up", MouseEventKind::Up(MouseButton::Middle));
+
+    map.insert("left:drag", MouseEventKind::Drag(MouseButton::Left));
+    map.insert("right:drag", MouseEventKind::Drag(MouseButton::Right));
+    map.insert("mid:drag", MouseEventKind::Drag(MouseButton::Middle));
+
+    map.insert("move", MouseEventKind::Moved);
+    map.insert("scrollup", MouseEventKind::ScrollUp);
+    map.insert("scrolldown", MouseEventKind::ScrollDown);
+
+    map
+});
+
+pub fn parse_mouse_event(text: &str) -> MouseEvent {
+    let token_list = super::parse_tokens(text);
+    gen_mouse_event_from_tokenlist(&token_list, text)
+}
+
+fn gen_mouse_event_from_tokenlist(token_list: &[Token], text: &str) -> MouseEvent {
+    let mut kind = None;
+    let mut modifiers = KeyModifiers::NONE;
+
+    let mut token_iter = token_list.iter().peekable();
+
+    while let Some(token) = token_iter.peek() {
+        match token {
+            Token::Separator => {
+                token_iter.next();
+                assert!(
+                    !(token_iter.peek() == Some(&&Token::Separator)),
+                    "'{}': Multiple separators found consecutively",
+                    text
+                );
+            }
+            Token::SingleChar(c) => {
+                token_iter.next();
+                MODIFIERS.get(c).map_or_else(
+                    || {
+                        panic!("'{}': Invalid keymodifier '{}' given", text, c);
+                    },
+                    |m| {
+                        if token_iter.next() == Some(&Token::Separator) {
+                            assert!(
+                                !modifiers.contains(*m),
+                                "'{}': Multiple instances of same modifier given",
+                                text
+                            );
+                            modifiers.insert(*m);
+                        } else {
+                            panic!("'{}' Invalid key input sequence given", text);
+                        }
+                    },
+                );
+            }
+            Token::MultipleChar(c) => {
+                let c = c.to_ascii_lowercase().to_string();
+                MOUSE_ACTIONS.get(c.as_str()).map_or_else(
+                    || panic!("'{}': Invalid key input sequence given", text),
+                    |k| {
+                        if kind.is_none() {
+                            kind = Some(*k);
+                        } else {
+                            panic!("'{}': Invalid key input sequence given", text);
+                        }
+                    },
+                );
+                token_iter.next();
+            }
+        }
+    }
+    MouseEvent {
+        kind: kind.unwrap_or_else(|| panic!("No MouseEventKind found for '{}", text)),
+        modifiers,
+        row: 0,
+        column: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_mouse_event;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    #[test]
+    fn test_without_modifiers() {
+        assert_eq!(
+            parse_mouse_event("left:down"),
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                modifiers: KeyModifiers::NONE,
+                row: 0,
+                column: 0,
+            }
+        );
+
+        assert_eq!(
+            parse_mouse_event("mid:up"),
+            MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Middle),
+                modifiers: KeyModifiers::NONE,
+                row: 0,
+                column: 0,
+            }
+        );
+
+        assert_eq!(
+            parse_mouse_event("right:down"),
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Right),
+                modifiers: KeyModifiers::NONE,
+                row: 0,
+                column: 0,
+            }
+        );
+        assert_eq!(
+            parse_mouse_event("scrollup"),
+            MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                modifiers: KeyModifiers::NONE,
+                row: 0,
+                column: 0,
+            }
+        );
+        assert_eq!(
+            parse_mouse_event("move"),
+            MouseEvent {
+                kind: MouseEventKind::Moved,
+                modifiers: KeyModifiers::NONE,
+                row: 0,
+                column: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn test_with_modifiers() {
+        assert_eq!(
+            parse_mouse_event("m-left:down"),
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                modifiers: KeyModifiers::ALT,
+                row: 0,
+                column: 0,
+            }
+        );
+
+        assert_eq!(
+            parse_mouse_event("m-c-mid:up"),
+            MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Middle),
+                modifiers: KeyModifiers::ALT | KeyModifiers::CONTROL,
+                row: 0,
+                column: 0,
+            }
+        );
+        assert_eq!(
+            parse_mouse_event("c-scrollup"),
+            MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                modifiers: KeyModifiers::CONTROL,
+                row: 0,
+                column: 0,
+            }
+        );
+        assert_eq!(
+            parse_mouse_event("m-c-s-move"),
+            MouseEvent {
+                kind: MouseEventKind::Moved,
+                modifiers: KeyModifiers::all(),
+                row: 0,
+                column: 0,
+            }
+        );
+    }
+}

--- a/src/input/event_wrapper.rs
+++ b/src/input/event_wrapper.rs
@@ -1,0 +1,176 @@
+use super::{InputClassifier, InputEvent};
+use crate::PagerState;
+use crossterm::event::{Event, MouseEvent};
+use std::{
+    collections::hash_map::RandomState, collections::HashMap, hash::BuildHasher, hash::Hash,
+    sync::Arc,
+};
+
+type EventReturnType = Arc<dyn Fn(Event, &PagerState) -> InputEvent + Send + Sync>;
+
+pub struct HashedEventRegister<S>(HashMap<EventWrapper, EventReturnType, S>);
+
+#[derive(Copy, Clone, Eq)]
+enum EventWrapper {
+    ExactMatchEvent(Event),
+    WildEvent,
+}
+
+impl From<Event> for EventWrapper {
+    fn from(e: Event) -> Self {
+        Self::ExactMatchEvent(e)
+    }
+}
+
+impl From<&Event> for EventWrapper {
+    fn from(e: &Event) -> Self {
+        Self::ExactMatchEvent(*e)
+    }
+}
+
+impl PartialEq for EventWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::ExactMatchEvent(Event::Mouse(MouseEvent {
+                    kind, modifiers, ..
+                })),
+                Self::ExactMatchEvent(Event::Mouse(MouseEvent {
+                    kind: o_kind,
+                    modifiers: o_modifiers,
+                    ..
+                })),
+            ) => kind == o_kind && modifiers == o_modifiers,
+            (
+                Self::ExactMatchEvent(Event::Resize(..)),
+                Self::ExactMatchEvent(Event::Resize(..)),
+            )
+            | (Self::WildEvent, Self::WildEvent) => true,
+            (Self::ExactMatchEvent(ev), Self::ExactMatchEvent(o_ev)) => ev == o_ev,
+            _ => false,
+        }
+    }
+}
+
+impl Hash for EventWrapper {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let tag = std::mem::discriminant(self);
+        tag.hash(state);
+        match self {
+            Self::ExactMatchEvent(Event::Mouse(MouseEvent {
+                kind, modifiers, ..
+            })) => {
+                kind.hash(state);
+                modifiers.hash(state);
+            }
+            Self::WildEvent | Self::ExactMatchEvent(Event::Resize(..)) => {}
+            Self::ExactMatchEvent(v) => {
+                v.hash(state);
+            }
+        }
+    }
+}
+
+impl<S> HashedEventRegister<S>
+where
+    S: BuildHasher,
+{
+    fn new(s: S) -> Self {
+        Self(HashMap::with_hasher(s))
+    }
+
+    pub fn insert_wild_event_matcher(
+        &mut self,
+        v: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+    ) {
+        self.0.insert(EventWrapper::WildEvent, Arc::new(v));
+    }
+
+    pub fn get(&self, k: &Event) -> Option<&EventReturnType> {
+        self.0
+            .get(&k.into())
+            .map_or_else(|| self.0.get(&EventWrapper::WildEvent), |k| Some(k))
+    }
+
+    pub fn add_resize_event(
+        &mut self,
+        v: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+    ) {
+        let v = Arc::new(v);
+        self.0
+            .insert(EventWrapper::ExactMatchEvent(Event::Resize(0, 0)), v);
+    }
+
+    pub fn remove_resize_event(&mut self) {
+        self.0.remove(&EventWrapper::ExactMatchEvent(Event::Resize(0, 0)));
+    }
+
+}
+
+// Key event Insertions functions
+impl<S> HashedEventRegister<S>
+where
+    S: BuildHasher,
+{
+    pub fn add_key_events(
+        &mut self,
+        keys: &[&str],
+        v: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+    ) {
+        let v = Arc::new(v);
+        for k in keys {
+            self.0.insert(
+                Event::Key(super::definitions::keydefs::parse_key_event(k)).into(),
+                v.clone(),
+            );
+        }
+    }
+
+    pub fn remove_key_events(&mut self, keys: &[&str]) {
+        for k in keys {
+            self.0.remove(&Event::Key(super::definitions::keydefs::parse_key_event(k)).into());
+        }
+    }
+
+}
+
+// Mouse event insertions functions
+impl<S> HashedEventRegister<S>
+where
+    S: BuildHasher,
+{
+    pub fn add_mouse_events(
+        &mut self,
+        keys: &[&str],
+        v: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+    ) {
+        let v = Arc::new(v);
+        for k in keys {
+            self.0.insert(
+                Event::Mouse(super::definitions::mousedefs::parse_mouse_event(k)).into(),
+                v.clone(),
+            );
+        }
+    }
+
+    pub fn remove_mouse_events(&mut self, keys: &[&str]) {
+        for k in keys {
+            self.0.remove(&Event::Mouse(super::definitions::mousedefs::parse_mouse_event(k)).into());
+        }
+    }
+}
+
+impl Default for HashedEventRegister<RandomState> {
+    fn default() -> Self {
+        Self::new(RandomState::new())
+    }
+}
+
+impl<S> InputClassifier for HashedEventRegister<S>
+where
+    S: BuildHasher,
+{
+    fn classify_input(&self, ev: Event, ps: &crate::PagerState) -> Option<InputEvent> {
+        self.get(&ev).map(|c| c(ev, ps))
+    }
+}


### PR DESCRIPTION
This set of changes will allow minus to define key, mouse and resize
events to be declared natively through minus's APIs and not requiring end applications
to interact with the underlying crossterm crate.

This means that keybindings like Ctrl+L can be declared into minus like this

```rust
pager.add_input_event(KeyBind("c-l", |pagerstate| {
     ...
}));
```

**Note: Do note that this is not the final implementation and there will be large variations between this and the actual implementation that comes-up.**

This has the advantage that end-applications can now add to, modify, or remove minus's default event binding without needing
to copy the entire matcher function and then change the parts that they want.

This new API will not deprecate the previous way of defining input binding so existing code will work without any breakage. 