### PR TITLE
init: Use crossbeam scoped threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "^1"
 regex = { version = ">=1.5.5", optional = true }
 crossbeam-channel = "0.5.1"
 once_cell = "1.9.0"
+crossbeam-utils = "0.8.8"
 
 [features]
 search = [ "regex" ]


### PR DESCRIPTION
This resolves a issue that is required in further implementation of native input bindings. Using scoped thread also ensures that both the screen updater and event reader function exit at the same scope, which should be the case most of the time. 