### PR TITLE
init_core: Handle runtime panics better

### DIFF
--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -109,7 +109,6 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
                 true,
             ));
             panic_hook(pinfo);
-            std::process::exit(1);
         }));
     }
 
@@ -339,7 +338,11 @@ fn event_reader(
             .map_err(|e| MinusError::HandleEvent(e.into()))?
         {
             let ev = event::read().map_err(|e| MinusError::HandleEvent(e.into()))?;
-            let mut guard = ps.lock().unwrap();
+            let guard = ps.lock();
+            if guard.is_err() {
+                break;
+            }
+            let mut guard = guard.unwrap();
             // Get the events
             let input = guard.input_classifier.classify_input(ev, &guard);
             if let Some(iev) = input {

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -109,6 +109,7 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
                 true,
             ));
             panic_hook(pinfo);
+            std::process::exit(1);
         }));
     }
 
@@ -142,16 +143,7 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
                     &input_thread_running,
                 )
             });
-            let (tr1, tr2) = (t1.join(), t2.join());
-
-            let (mut r1, mut r2) = (Ok(()), Ok(()));
-
-            if let Err(e) = tr1 {
-                r1 = Err(crate::error::MinusError::Panic(e));
-            }
-            if let Err(e) = tr2 {
-                r2 = Err(crate::error::MinusError::Panic(e));
-            }
+            let (r1, r2) = (t1.join().unwrap(), t2.join().unwrap());
             (r1, r2)
         })
         .unwrap();
@@ -347,12 +339,7 @@ fn event_reader(
             .map_err(|e| MinusError::HandleEvent(e.into()))?
         {
             let ev = event::read().map_err(|e| MinusError::HandleEvent(e.into()))?;
-            let guard = ps.lock();
-            if guard.is_err() {
-                break;
-            }
-            let mut guard = guard.unwrap();
-
+            let mut guard = ps.lock().unwrap();
             // Get the events
             let input = guard.input_classifier.classify_input(ev, &guard);
             if let Some(iev) = input {

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -99,16 +99,17 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
     term::setup(&out)?;
 
     {
-        panic::set_hook(Box::new(|pinfo| {
-            let panic_hook = panic::take_hook();
+        let panic_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |pinfo| {
             // While silently ignoring error is considered a bad practice, we are forced to do it here
             // as we cannot use the ? and panicking here will cause UB.
             drop(term::cleanup(
                 stdout(),
-                &crate::ExitStrategy::ProcessQuit,
+                &crate::ExitStrategy::PagerQuit,
                 true,
             ));
             panic_hook(pinfo);
+            std::process::exit(1);
         }));
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,10 +103,8 @@ pub enum MinusError {
     #[cfg_attr(docsrs, doc(cfg(feature = "search")))]
     SearchExpError(#[from] RegexError),
 
-    #[cfg(feature = "tokio")]
-    #[error(transparent)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-    JoinError(#[from] tokio::task::JoinError),
+    #[error("Minus panicked")]
+    Panic(Box<dyn std::any::Any + Send>),
 }
 
 // Just for  convinience helper which is useful in many places

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,8 +103,10 @@ pub enum MinusError {
     #[cfg_attr(docsrs, doc(cfg(feature = "search")))]
     SearchExpError(#[from] RegexError),
 
-    #[error("Minus panicked")]
-    Panic(Box<dyn std::any::Any + Send>),
+    #[cfg(feature = "tokio")]
+    #[error(transparent)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+    JoinError(#[from] tokio::task::JoinError),
 }
 
 // Just for  convinience helper which is useful in many places


### PR DESCRIPTION
In previous versions, during a panic the error message (and backtrace possibly) might not get displayed after a panic. This happened because
they were printed on the alternate screen and after the program exited, the terminal automatically switches to the main screen. hence
the message never gets to be displayed.

This patch fixes this by doing a cleanup before proceeding furthur on the unwinding of the panic