### PR TITLE
bugfix: Regression in quitting in v5.0.4

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -1,12 +1,15 @@
 //! Provides the [`handle_event`] function
-use std::{io::Write, sync::atomic::AtomicBool};
+use std::sync::{atomic::AtomicBool, Arc};
+
+#[cfg(feature = "search")]
+use std::io::Write;
 
 use super::events::Event;
 #[cfg(feature = "search")]
 use super::search;
 use crate::{error::MinusError, input::InputEvent, PagerState};
 #[cfg(feature = "search")]
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 /// Respond based on the type of event
 ///
@@ -14,9 +17,11 @@ use std::sync::{Arc, Mutex};
 /// - Mutating fields of [`PagerState`]
 /// - Handle cleanup and exits
 /// - Call search related functions
+#[cfg_attr(not(feature = "search"), allow(unused_mut))]
+#[cfg_attr(not(feature = "search"), allow(clippy::unnecessary_wraps))]
 pub fn handle_event(
     ev: Event,
-    mut out: &mut impl Write,
+    #[cfg(feature = "search")] mut out: &mut impl Write,
     p: &mut PagerState,
     is_exitted: &Arc<AtomicBool>,
     #[cfg(feature = "search")] event_thread_running: &Arc<Mutex<()>>,
@@ -133,7 +138,8 @@ pub fn handle_event(
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "search")]
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
+    use std::sync::{atomic::AtomicBool, Arc};
 
     use super::super::events::Event;
     use crate::{ExitStrategy, PagerState};
@@ -146,15 +152,17 @@ mod tests {
     fn set_data() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetData(TEST_STR.to_string());
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -167,24 +175,27 @@ mod tests {
         let mut ps = PagerState::new().unwrap();
         let ev1 = Event::AppendData(format!("{}\n", TEST_STR));
         let ev2 = Event::AppendData(TEST_STR.to_string());
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev1,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
         .unwrap();
         handle_event(
             ev2,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -199,15 +210,17 @@ mod tests {
     fn set_prompt() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetPrompt(TEST_STR.to_string());
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -219,15 +232,17 @@ mod tests {
     fn send_message() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SendMessage(TEST_STR.to_string());
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -240,15 +255,17 @@ mod tests {
     fn set_run_no_overflow() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetRunNoOverflow(false);
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -260,15 +277,17 @@ mod tests {
     fn set_exit_strategy() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetExitStrategy(ExitStrategy::PagerQuit);
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )
@@ -280,15 +299,17 @@ mod tests {
     fn add_exit_callback() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::AddExitCallback(Box::new(|| println!("Hello World")));
+        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
+            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &etr,
         )

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -22,7 +22,10 @@ use once_cell::sync::OnceCell;
 use std::{
     io::{stdout, Stdout},
     panic,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 #[cfg(feature = "static_output")]
 use {super::display::write_lines, crossterm::tty::IsTty};
@@ -125,21 +128,27 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
 
     let (r1, r2) =
         crossbeam_utils::thread::scope(|s| -> (Result<(), MinusError>, Result<(), MinusError>) {
-            let t1 = s.spawn(|_| {
+            // Has the user quitted
+            let is_exitted = Arc::new(AtomicBool::new(false));
+            let is_exitted2 = is_exitted.clone();
+
+            let t1 = s.spawn(move |_| {
                 event_reader(
                     &evtx,
                     &p1,
                     #[cfg(feature = "search")]
                     &input_thread_running2,
+                    is_exitted2,
                 )
             });
-            let t2 = s.spawn(|_| {
+            let t2 = s.spawn(move |_| {
                 start_reactor(
                     &rx,
                     &ps_mutex,
                     &out,
                     #[cfg(feature = "search")]
                     &input_thread_running,
+                    is_exitted,
                 )
             });
             let (r1, r2) = (t1.join().unwrap(), t2.join().unwrap());
@@ -170,9 +179,8 @@ fn start_reactor(
     ps: &Arc<Mutex<PagerState>>,
     out: &Stdout,
     #[cfg(feature = "search")] input_thread_running: &Arc<Mutex<()>>,
+    is_exitted: Arc<AtomicBool>,
 ) -> Result<(), MinusError> {
-    // Has the user quitted
-    let mut is_exitted: bool = false;
     let mut out_lock = out.lock();
 
     if let Ok(mut p) = ps.lock() {
@@ -184,7 +192,7 @@ fn start_reactor(
         #[cfg(feature = "dynamic_output")]
         Some(&RunMode::Dynamic) => loop {
             use std::{convert::TryInto, io::Write};
-            if is_exitted {
+            if is_exitted.load(Ordering::SeqCst) {
                 break;
             }
             let event = rx.recv();
@@ -202,7 +210,7 @@ fn start_reactor(
                         ev,
                         &mut out_lock,
                         &mut p,
-                        &mut is_exitted,
+                        &is_exitted,
                         #[cfg(feature = "search")]
                         input_thread_running,
                     )?;
@@ -264,7 +272,7 @@ fn start_reactor(
                         ev,
                         &mut out_lock,
                         &mut p,
-                        &mut is_exitted,
+                        &is_exitted,
                         #[cfg(feature = "search")]
                         input_thread_running,
                     )?;
@@ -274,7 +282,9 @@ fn start_reactor(
         },
         #[cfg(feature = "static_output")]
         Some(&RunMode::Static) => loop {
-            if is_exitted {
+            if is_exitted.load(Ordering::SeqCst) {
+                let p = ps.lock().unwrap();
+                term::cleanup(&mut out_lock, &p.exit_strategy, true)?;
                 break;
             }
 
@@ -284,7 +294,7 @@ fn start_reactor(
                     Event::UserInput(inp),
                     &mut out_lock,
                     &mut p,
-                    &mut is_exitted,
+                    &is_exitted,
                     #[cfg(feature = "search")]
                     input_thread_running,
                 )?;
@@ -315,7 +325,7 @@ fn generate_initial_state(
             ev,
             &mut out,
             &mut ps,
-            &mut false,
+            &Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "search")]
             &Arc::new(Mutex::new(())),
         )
@@ -327,8 +337,13 @@ fn event_reader(
     evtx: &Sender<Event>,
     ps: &Arc<Mutex<PagerState>>,
     #[cfg(feature = "search")] input_thread_running: &Arc<Mutex<()>>,
+    is_exitted: Arc<AtomicBool>,
 ) -> Result<(), MinusError> {
     loop {
+        if is_exitted.load(Ordering::SeqCst) {
+            break;
+        }
+
         #[cfg(feature = "search")]
         let ilock = input_thread_running.lock().unwrap();
         #[cfg(feature = "search")]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -20,7 +20,7 @@ static ANSI_REGEX: Lazy<Regex> = Lazy::new(|| {
         .unwrap()
 });
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "search")))]
 #[allow(clippy::module_name_repetitions)]
 /// Defines modes in which the search can run

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -8,7 +8,7 @@ use crate::minus_core::search::SearchMode;
 use crate::{LineNumbers, PagerState};
 
 /// Events handled by the `minus` pager.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(clippy::module_name_repetitions)]
 pub enum InputEvent {
     /// `Ctrl+C` or `Q`, exits the application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ pub use state::PagerState;
 pub type ExitCallbacks = Vec<Box<dyn FnMut() + Send + Sync + 'static>>;
 
 /// Behaviour that happens when the pager is exitted
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Eq)]
 pub enum ExitStrategy {
     /// Kill the entire application immediately.
     ///


### PR DESCRIPTION
The `q` or `Ctrl-c` command didn't properly quit the pager and didn't cleared the output in `PagerQuit` exit strategy. This occured because of redrawing after returning of the cleanup function. This patch fixes this performing the cleanup when the pager quits.

Closes #78