### PR TITLE
Use parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ textwrap = { version = "~0.13", default-features = false, features = ["unicode-w
 thiserror = "^1"
 regex = { version = ">=1.5.5", optional = true }
 crossbeam-channel = "0.5.1"
-once_cell = "1.9.0"
 crossbeam-utils = "0.8.8"
+parking_lot = "0.12.1"
+once_cell = { version = "1.15.0", features = ["parking_lot"] }
 
 [features]
 search = [ "regex" ]

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -8,8 +8,9 @@ use super::events::Event;
 #[cfg(feature = "search")]
 use super::search;
 use crate::{error::MinusError, input::InputEvent, PagerState};
+
 #[cfg(feature = "search")]
-use std::sync::Mutex;
+use std::sync::atomic::Ordering;
 
 /// Respond based on the type of event
 ///
@@ -25,7 +26,7 @@ pub fn handle_event(
     #[cfg(feature = "search")] mut out: &mut impl Write,
     p: &mut PagerState,
     is_exitted: &Arc<AtomicBool>,
-    #[cfg(feature = "search")] event_thread_running: &Arc<Mutex<()>>,
+    #[cfg(feature = "search")] event_thread_running: &Arc<AtomicBool>,
 ) -> Result<(), MinusError> {
     match ev {
         Event::SetData(text) => {
@@ -56,11 +57,11 @@ pub fn handle_event(
         Event::UserInput(InputEvent::Search(m)) => {
             p.search_mode = m;
             // Pause the main user input thread from running
-            let ilock = event_thread_running.lock().unwrap();
+            event_thread_running.store(false, Ordering::SeqCst);
             // Get the query
             let string = search::fetch_input(&mut out, p.search_mode, p.rows)?;
             // Continue the user input thread
-            drop(ilock);
+            event_thread_running.store(true, Ordering::SeqCst);
 
             if !string.is_empty() {
                 let regex = regex::Regex::new(string.as_str());
@@ -152,8 +153,6 @@ pub fn handle_event(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "search")]
-    use std::sync::Mutex;
     use std::sync::{atomic::AtomicBool, Arc};
 
     use super::super::events::Event;
@@ -170,7 +169,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,
@@ -193,7 +192,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev1,
@@ -228,7 +227,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,
@@ -250,7 +249,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,
@@ -273,7 +272,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,
@@ -295,7 +294,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,
@@ -317,7 +316,7 @@ mod tests {
         #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
-        let etr = Arc::new(Mutex::new(()));
+        let etr = Arc::new(AtomicBool::new(true));
 
         handle_event(
             ev,

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -74,7 +74,7 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
     let input_thread_running = Arc::new(AtomicBool::new(true));
 
     #[allow(unused_mut)]
-    let mut ps = generate_initial_state(
+    let mut ps = PagerState::generate_initial_state(
         &mut pager.rx,
         #[cfg(feature = "search")]
         &mut out,
@@ -316,34 +316,6 @@ This is most likely a bug. Please open an issue to the developers"
         ),
     }
     Ok(())
-}
-
-/// Generate the initial [`PagerState`]
-///
-/// This function creates a default [`PagerState`] and fetches all events present in the receiver
-/// to create the initial state. This is done before starting the pager so that we
-/// can make the optimizationss that are present in static pager mode.
-///
-/// # Errors
-///  This function will return an error if it could not create the default [`PagerState`]or fails
-///  to process the events
-fn generate_initial_state(
-    rx: &mut Receiver<Event>,
-    #[cfg(feature = "search")] mut out: &mut Stdout,
-) -> Result<PagerState, MinusError> {
-    let mut ps = PagerState::new()?;
-    rx.try_iter().try_for_each(|ev| -> Result<(), MinusError> {
-        handle_event(
-            ev,
-            #[cfg(feature = "search")]
-            &mut out,
-            &mut ps,
-            &Arc::new(AtomicBool::new(false)),
-            #[cfg(feature = "search")]
-            &Arc::new(AtomicBool::new(true)),
-        )
-    })?;
-    Ok(ps)
 }
 
 fn event_reader(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,7 +1,6 @@
 #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
 mod display;
-#[cfg(any(feature = "dynamic_output", feature = "static_output"))]
-mod ev_handler;
+pub mod ev_handler;
 pub mod events;
 #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
 pub mod init;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,7 +10,6 @@ pub mod search;
 #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
 pub mod term;
 
-
 #[derive(PartialEq, Eq)]
 pub enum RunMode {
     #[cfg(feature = "static_output")]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,3 +9,19 @@ pub mod init;
 pub mod search;
 #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
 pub mod term;
+
+
+#[derive(PartialEq, Eq)]
+pub enum RunMode {
+    #[cfg(feature = "static_output")]
+    Static,
+    #[cfg(feature = "dynamic_output")]
+    Dynamic,
+    Uninitialized,
+}
+
+impl RunMode {
+    pub fn is_uninitialized(&self) -> bool {
+        *self == Self::Uninitialized
+    }
+}

--- a/src/dynamic_pager.rs
+++ b/src/dynamic_pager.rs
@@ -15,9 +15,9 @@ use crate::Pager;
 /// The function will return with an error if it encounters a error during paging.
 #[cfg_attr(docsrs, doc(cfg(feature = "dynamic_output")))]
 pub fn dynamic_paging(pager: Pager) -> Result<(), MinusError> {
-    let runmode = init::RUNMODE.lock();
+    let mut runmode = init::RUNMODE.lock();
     assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
-    *runmode = minus_core::RunMode::Static;
+    *runmode = minus_core::RunMode::Dynamic;
     drop(runmode);
     init::init_core(pager)
 }

--- a/src/dynamic_pager.rs
+++ b/src/dynamic_pager.rs
@@ -1,5 +1,5 @@
 use crate::error::MinusError;
-use crate::minus_core::init;
+use crate::minus_core::{self, init};
 use crate::Pager;
 
 /// Starts a asynchronously running pager
@@ -15,6 +15,9 @@ use crate::Pager;
 /// The function will return with an error if it encounters a error during paging.
 #[cfg_attr(docsrs, doc(cfg(feature = "dynamic_output")))]
 pub fn dynamic_paging(pager: Pager) -> Result<(), MinusError> {
-    assert!(init::RUNMODE.set(init::RunMode::Dynamic).is_ok(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
+    let runmode = init::RUNMODE.lock();
+    assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
+    *runmode = minus_core::RunMode::Static;
+    drop(runmode);
     init::init_core(pager)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,10 +1,21 @@
 #[cfg(feature = "search")]
 use crate::minus_core::search::{self, SearchMode};
-use crate::{error::TermError, input, wrap_str, ExitStrategy, LineNumbers};
+use crate::{
+    error::{MinusError, TermError},
+    input, wrap_str, ExitStrategy, LineNumbers,
+};
 use crossterm::{terminal, tty::IsTty};
 #[cfg(feature = "search")]
 use std::collections::BTreeSet;
-use std::io::stdout;
+#[cfg(feature = "search")]
+use std::io::Stdout;
+use std::{
+    io::stdout,
+    sync::{atomic::AtomicBool, Arc},
+};
+
+use crate::minus_core::{ev_handler::handle_event, events::Event};
+use crossbeam_channel::Receiver;
 
 /// Holds all information and configuration about the pager during
 /// its un time.
@@ -143,6 +154,36 @@ impl PagerState {
 
         state.format_prompt();
         Ok(state)
+    }
+
+    /// Generate the initial [`PagerState`]
+    ///
+    /// [`init_core`](crate::minus_core::init::init_core) calls this functions for creating the PagerState.
+    ///
+    /// This function creates a default [`PagerState`] and fetches all events present in the receiver
+    /// to create the initial state. This is done before starting the pager so that
+    /// the optimizationss can be applied.
+    ///
+    /// # Errors
+    /// This function will return an error if it could not create the default [`PagerState`] or fails
+    /// to process the events
+    pub fn generate_initial_state(
+        rx: &mut Receiver<Event>,
+        #[cfg(feature = "search")] mut out: &mut Stdout,
+    ) -> Result<Self, MinusError> {
+        let mut ps = Self::new()?;
+        rx.try_iter().try_for_each(|ev| -> Result<(), MinusError> {
+            handle_event(
+                ev,
+                #[cfg(feature = "search")]
+                &mut out,
+                &mut ps,
+                &Arc::new(AtomicBool::new(false)),
+                #[cfg(feature = "search")]
+                &Arc::new(AtomicBool::new(true)),
+            )
+        })?;
+        Ok(ps)
     }
 
     pub(crate) fn num_lines(&self) -> usize {

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -26,7 +26,7 @@ use crate::{error::MinusError, Pager};
 #[cfg_attr(docsrs, doc(cfg(feature = "static_output")))]
 #[allow(clippy::needless_pass_by_value)]
 pub fn page_all(pager: Pager) -> Result<(), MinusError> {
-    let runmode = init::RUNMODE.lock();
+    let mut runmode = init::RUNMODE.lock();
     assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
     *runmode = minus_core::RunMode::Static;
     drop(runmode);

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -1,7 +1,7 @@
 //! Contains function for displaying static data
 //!
 //! This module provides provides the [`page_all`] function to display static output via minus
-use crate::minus_core::init;
+use crate::minus_core::{self, init};
 use crate::{error::MinusError, Pager};
 
 /// Display static information to the screen
@@ -26,7 +26,11 @@ use crate::{error::MinusError, Pager};
 #[cfg_attr(docsrs, doc(cfg(feature = "static_output")))]
 #[allow(clippy::needless_pass_by_value)]
 pub fn page_all(pager: Pager) -> Result<(), MinusError> {
-    assert!(init::RUNMODE.set(init::RunMode::Static).is_ok(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
+    let runmode = init::RUNMODE.lock();
+    assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably bcause another instance of minus is already running");
+    *runmode = minus_core::RunMode::Static;
+    drop(runmode);
+
     init::init_core(pager)?;
     Ok(())
 }


### PR DESCRIPTION
This PR introduces parking_lot sync primitives to replace Rust's `std` types for faster and much smaller sync types.

This also fixes a bug where calling `dynamic_paging` or `static_paging` again after the first pager would cause a panic. 