### PR TITLE
init: Simplify screen cleanup code

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -1,8 +1,7 @@
 //! Provides the [`handle_event`] function
-use std::sync::{atomic::AtomicBool, Arc};
 
-#[cfg(feature = "search")]
 use std::io::Write;
+use std::sync::{atomic::AtomicBool, Arc};
 
 #[cfg(feature = "search")]
 use super::search;
@@ -22,7 +21,7 @@ use std::sync::Mutex;
 #[allow(clippy::too_many_lines)]
 pub fn handle_event(
     ev: Event,
-    #[cfg(feature = "search")] mut out: &mut impl Write,
+    mut out: &mut impl Write,
     p: &mut PagerState,
     is_exitted: &Arc<AtomicBool>,
     #[cfg(feature = "search")] event_thread_running: &Arc<Mutex<()>>,
@@ -168,14 +167,12 @@ mod tests {
     fn set_data() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetData(TEST_STR.to_string());
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -191,14 +188,12 @@ mod tests {
         let mut ps = PagerState::new().unwrap();
         let ev1 = Event::AppendData(format!("{}\n", TEST_STR));
         let ev2 = Event::AppendData(TEST_STR.to_string());
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev1,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -208,7 +203,6 @@ mod tests {
         .unwrap();
         handle_event(
             ev2,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -226,14 +220,12 @@ mod tests {
     fn set_prompt() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetPrompt(TEST_STR.to_string());
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -248,14 +240,12 @@ mod tests {
     fn send_message() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SendMessage(TEST_STR.to_string());
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -271,14 +261,12 @@ mod tests {
     fn set_run_no_overflow() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetRunNoOverflow(false);
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -293,14 +281,12 @@ mod tests {
     fn set_exit_strategy() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::SetExitStrategy(ExitStrategy::PagerQuit);
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),
@@ -315,14 +301,12 @@ mod tests {
     fn add_exit_callback() {
         let mut ps = PagerState::new().unwrap();
         let ev = Event::AddExitCallback(Box::new(|| println!("Hello World")));
-        #[cfg(feature = "search")]
         let mut out = Vec::new();
         #[cfg(feature = "search")]
         let etr = Arc::new(Mutex::new(()));
 
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -4,9 +4,9 @@ use std::sync::{atomic::AtomicBool, Arc};
 #[cfg(feature = "search")]
 use std::io::Write;
 
-use super::events::Event;
 #[cfg(feature = "search")]
 use super::search;
+use super::{events::Event, term};
 use crate::{error::MinusError, input::InputEvent, PagerState};
 #[cfg(feature = "search")]
 use std::sync::Mutex;
@@ -34,6 +34,7 @@ pub fn handle_event(
         Event::UserInput(InputEvent::Exit) => {
             p.exit();
             is_exitted.store(true, std::sync::atomic::Ordering::SeqCst);
+            term::cleanup(&mut out, &p.exit_strategy, true)?;
         }
         Event::UserInput(InputEvent::UpdateUpperMark(um)) => p.upper_mark = um,
         Event::UserInput(InputEvent::RestorePrompt) => {

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -58,6 +58,7 @@ impl Debug for Event {
 }
 
 impl Event {
+    #[allow(dead_code)]
     pub(crate) const fn is_exit_event(&self) -> bool {
         matches!(self, Self::UserInput(InputEvent::Exit))
     }

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -58,6 +58,10 @@ impl Debug for Event {
 }
 
 impl Event {
+    pub(crate) const fn is_exit_event(&self) -> bool {
+        matches!(self, Self::UserInput(InputEvent::Exit))
+    }
+
     #[cfg(feature = "dynamic_output")]
     pub(crate) const fn required_immidiate_screen_update(&self) -> bool {
         matches!(

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -81,11 +81,7 @@ pub fn init_core(mut pager: Pager) -> std::result::Result<(), MinusError> {
     let input_thread_running = Arc::new(Mutex::new(()));
 
     #[allow(unused_mut)]
-    let mut ps = generate_initial_state(
-        &mut pager.rx,
-        #[cfg(feature = "search")]
-        &mut out,
-    )?;
+    let mut ps = generate_initial_state(&mut pager.rx, &mut out)?;
 
     // Static mode checks
     #[cfg(feature = "static_output")]
@@ -215,7 +211,6 @@ fn start_reactor(
                     let is_exit_event = ev.is_exit_event();
                     handle_event(
                         ev,
-                        #[cfg(feature = "search")]
                         &mut out_lock,
                         &mut p,
                         is_exitted,
@@ -277,7 +272,6 @@ fn start_reactor(
                 Ok(ev) => {
                     handle_event(
                         ev,
-                        #[cfg(feature = "search")]
                         &mut out_lock,
                         &mut p,
                         is_exitted,
@@ -294,7 +288,6 @@ fn start_reactor(
                 let mut p = ps.lock().unwrap();
                 handle_event(
                     Event::UserInput(inp),
-                    #[cfg(feature = "search")]
                     &mut out_lock,
                     &mut p,
                     is_exitted,
@@ -323,13 +316,12 @@ fn start_reactor(
 ///  to process the events
 fn generate_initial_state(
     rx: &mut Receiver<Event>,
-    #[cfg(feature = "search")] mut out: &mut Stdout,
+    mut out: &mut Stdout,
 ) -> Result<PagerState, MinusError> {
     let mut ps = PagerState::new()?;
     rx.try_iter().try_for_each(|ev| -> Result<(), MinusError> {
         handle_event(
             ev,
-            #[cfg(feature = "search")]
             &mut out,
             &mut ps,
             &Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
For events that require immidiate screen update, which also includes a exit event, start_reactor check whether it is an exit event and avoids redrawing the screen and quits the pager