### PR TITLE
Intelligently redraw the screen on movement

### DIFF
--- a/src/core/display/mod.rs
+++ b/src/core/display/mod.rs
@@ -1,12 +1,106 @@
 use crossterm::{
     cursor::MoveTo,
+    execute, queue,
     style::Attribute,
     terminal::{Clear, ClearType},
 };
 
 use std::{convert::TryInto, io::Write};
 
+use super::term::move_cursor;
 use crate::{error::MinusError, PagerState};
+
+pub fn draw2(
+    out: &mut impl Write,
+    p: &mut PagerState,
+    new_upper_mark: &mut usize,
+) -> Result<(), MinusError> {
+    let line_count = p.num_lines();
+
+    // Reduce one row for prompt/messages
+    //
+    // NOTE This should be the value of rows that should be used throughout this function.
+    // Don't use PagerState::rows, it might lead to wrong output
+    let writable_rows = p.rows.saturating_sub(1);
+
+    let delta = new_upper_mark.abs_diff(p.upper_mark);
+
+    // Calculate the lower_bound for current and new upper marks
+    // by adding either the rows or line_count depending on the minimality
+    let lower_bound = p.upper_mark.saturating_add(writable_rows.min(line_count));
+    let new_lower_bound = new_upper_mark.saturating_add(writable_rows.min(line_count));
+
+    // If lower_mark is more than line_count, there could be two cases
+    //
+    // If the lower_bound is greater than the avilable line count, we set it to such a value
+    // so that the last page can be displayed entirely, i.e never scroll past the last line
+    if new_lower_bound > line_count {
+        *new_upper_mark = line_count.saturating_sub(writable_rows);
+    }
+
+    // Sometimes the value of delta is too large that we can rather use the value of the writable rows to
+    // achieve the same effect with better performance. This means that we have to less lines to the terminal
+    //
+    // Think of it like this:-
+    // Let's say the current upper mark is at 100 and writable rows is 25. Now if there is a jump of 200th line,
+    // then instead of writing 100 lines, we can just jump to the 200 line and display the next 25 lines from there on.
+    //
+    // Hence we use get the minimum of those for displaying
+    //
+    // NOTE that the large delta case may not always be true in case of scrolling down. Actually this method produces
+    // wrong output if this is not the case hence we still rely on using lower bounds method. But for scrolling up, we
+    // need this value whatever the value of delta be.
+    let normalized_delta = delta.min(writable_rows);
+
+    let lines = if *new_upper_mark > p.upper_mark {
+        queue!(
+            out,
+            crossterm::terminal::ScrollUp(normalized_delta.try_into().unwrap())
+        )?;
+        // Move up the cursor one extra line to cleanup the old junk prompt
+        move_cursor(
+            out,
+            0,
+            p.rows
+                .saturating_sub(normalized_delta + 1)
+                .try_into()
+                .unwrap(),
+            false,
+        )?;
+        queue!(out, Clear(ClearType::CurrentLine))?;
+
+        if normalized_delta < p.rows {
+            p.get_flattened_lines_with_bounds(lower_bound, new_lower_bound)
+        } else {
+            p.get_flattened_lines_with_bounds(
+                *new_upper_mark,
+                new_upper_mark.saturating_add(normalized_delta),
+            )
+        }
+    } else if *new_upper_mark < p.upper_mark {
+        execute!(
+            out,
+            crossterm::terminal::ScrollDown(delta.try_into().unwrap())
+        )?;
+        move_cursor(out, 0, 0, false)?;
+
+        p.get_flattened_lines_with_bounds(
+            *new_upper_mark,
+            new_upper_mark.saturating_add(normalized_delta),
+        )
+    } else {
+        &[]
+    };
+
+    for line in lines {
+        writeln!(out, "\r{}", line)?;
+    }
+
+    super::display::write_prompt(out, &p.displayed_prompt, p.rows.try_into().unwrap())?;
+    out.flush()?;
+
+    Ok(())
+}
 
 /// Draws the scrren
 ///
@@ -17,8 +111,6 @@ use crate::{error::MinusError, PagerState};
 ///     - If there is one, it will display it at the prompt site
 ///     - If there isn't one, it will display the prompt in place of it
 pub fn draw(out: &mut impl Write, pager: &mut PagerState) -> Result<(), MinusError> {
-    use crossterm::queue;
-
     super::term::move_cursor(out, 0, 0, false)?;
     queue!(out, Clear(ClearType::All))?;
 

--- a/src/core/display/mod.rs
+++ b/src/core/display/mod.rs
@@ -10,6 +10,12 @@ use std::{cmp::Ordering, convert::TryInto, io::Write};
 use super::term::move_cursor;
 use crate::{error::MinusError, PagerState};
 
+/// Handles drawing of screen based on movement
+///
+/// Refreshing the entire terminal can be costly, especially on high resolution displays and this cost can turns out to be
+/// very high if that redrawing is required on every movement of the pager, even for small changes.
+/// This function calculates what part of screen needs to be redrawed on scrolling up/down and based on that, it redraws
+/// only that part of the terminal.
 pub fn draw_for_change(
     out: &mut impl Write,
     p: &mut PagerState,

--- a/src/core/display/mod.rs
+++ b/src/core/display/mod.rs
@@ -58,29 +58,27 @@ pub fn draw_for_change(
 
     let lines = match (*new_upper_mark).cmp(&p.upper_mark) {
         Ordering::Greater => {
-            if delta < writable_rows {
-                // Scroll down `normalized_delta` lines, and put the cursor one line above, where the old prompt would present.
-                // Clear it off and start displaying new data.
-                queue!(
-                    out,
-                    crossterm::terminal::ScrollUp(normalized_delta.try_into().unwrap())
-                )?;
-                move_cursor(
-                    out,
-                    0,
-                    p.rows
-                        .saturating_sub(normalized_delta + 1)
-                        .try_into()
-                        .unwrap(),
-                    false,
-                )?;
-                queue!(out, Clear(ClearType::CurrentLine))?;
+            // Scroll down `normalized_delta` lines, and put the cursor one line above, where the old prompt would present.
+            // Clear it off and start displaying new dta.
+            dbg!(normalized_delta);
+            queue!(
+                out,
+                crossterm::terminal::ScrollUp(normalized_delta.try_into().unwrap())
+            )?;
+            move_cursor(
+                out,
+                0,
+                p.rows
+                    .saturating_sub(normalized_delta + 1)
+                    .try_into()
+                    .unwrap(),
+                false,
+            )?;
+            queue!(out, Clear(ClearType::CurrentLine))?;
 
+            if delta < writable_rows {
                 p.get_flattened_lines_with_bounds(lower_bound, new_lower_bound)
             } else {
-                // Move the cursor to the origin and clear everything to start displaying new data
-                move_cursor(out, 0, 0, false)?;
-                queue!(out, Clear(ClearType::All))?;
                 p.get_flattened_lines_with_bounds(
                     *new_upper_mark,
                     new_upper_mark.saturating_add(normalized_delta),
@@ -90,7 +88,7 @@ pub fn draw_for_change(
         Ordering::Less => {
             execute!(
                 out,
-                crossterm::terminal::ScrollDown(delta.try_into().unwrap())
+                crossterm::terminal::ScrollDown(normalized_delta.try_into().unwrap())
             )?;
             move_cursor(out, 0, 0, false)?;
 
@@ -99,7 +97,7 @@ pub fn draw_for_change(
                 new_upper_mark.saturating_add(normalized_delta),
             )
         }
-        Ordering::Equal => &[],
+        Ordering::Equal => return Ok(()),
     };
 
     for line in lines {

--- a/src/core/display/tests.rs
+++ b/src/core/display/tests.rs
@@ -24,7 +24,7 @@ fn short_no_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\rA line\n\rAnother line",
+        "\rA line\n\rAnother line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -37,7 +37,7 @@ fn short_no_line_numbers() {
     // The number of lines is less than 'rows' so 'upper_mark' will be 0 even
     // if we set it to 1. This is done because everything can be displayed without problems.
     assert_eq!(
-        "\rA line\n\rAnother line",
+        "\rA line\n\rAnother line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -58,21 +58,21 @@ fn long_no_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\rA line\n\rAnother line\n\rThird line",
+        "\rA line\n\rAnother line\n\rThird line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
 
     // This ensures that asking for a position other than 0 works.
     let mut out = Vec::with_capacity(lines.len());
-    pager.lines = "Another line\nThird line\nFourth line\nFifth line".to_string();
+    pager.lines = "Another line\nThird line\nFourth line\nFifth line\n".to_string();
     pager.upper_mark = 1;
     pager.format_lines();
 
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\rThird line\n\rFourth line\n\rFifth line",
+        "\rThird line\n\rFourth line\n\rFifth line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -85,7 +85,7 @@ fn long_no_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\rThird line\n\rFourth line\n\rFifth line",
+        "\rThird line\n\rFourth line\n\rFifth line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -104,7 +104,7 @@ fn short_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r     1. A line\n\r     2. Another line",
+        "\r     1. A line\n\r     2. Another line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -118,7 +118,7 @@ fn short_with_line_numbers() {
     // The number of lines is less than 'rows' so 'upper_mark' will be 0 even
     // if we set it to 1. This is done because everything can be displayed without problems.
     assert_eq!(
-        "\r     1. A line\n\r     2. Another line",
+        "\r     1. A line\n\r     2. Another line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -139,7 +139,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r     1. A line\n\r     2. Another line\n\r     3. Third line",
+        "\r     1. A line\n\r     2. Another line\n\r     3. Third line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 0);
@@ -151,7 +151,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line",
+        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -164,7 +164,7 @@ fn long_with_line_numbers() {
     assert!(write_lines(&mut out, &mut pager).is_ok());
 
     assert_eq!(
-        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line",
+        "\r     2. Another line\n\r     3. Third line\n\r     4. Fourth line\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 1);
@@ -193,7 +193,7 @@ fn big_line_numbers_are_padded() {
     // The padding should have inserted a space before the numbers that are less than 100.
     assert_eq!(
         "\r      96. L95\n\r      97. L96\n\r      98. L97\n\r      99. L98\n\r     100. \
-         L99\n\r     101. L100\n\r     102. L101\n\r     103. L102\n\r     104. L103\n\r     105. L104",
+         L99\n\r     101. L100\n\r     102. L101\n\r     103. L102\n\r     104. L103\n\r     105. L104\n",
         String::from_utf8(out).expect("Should have written valid UTF-8")
     );
     assert_eq!(pager.upper_mark, 95);
@@ -231,7 +231,7 @@ fn draw_short_no_line_numbers() {
     pager.line_numbers = LineNumbers::AlwaysOff;
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -241,7 +241,7 @@ fn draw_short_no_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 1;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     // The number of lines is less than 'rows' so 'upper_mark' will be 0 even
     // if we set it to 1. This is done because everything can be displayed without problems.
@@ -262,7 +262,7 @@ fn draw_long_no_line_numbers() {
     pager.lines = lines.to_string();
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -273,7 +273,7 @@ fn draw_long_no_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 1;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -285,7 +285,7 @@ fn draw_long_no_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 3;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -302,7 +302,7 @@ fn draw_short_with_line_numbers() {
     pager.line_numbers = LineNumbers::Enabled;
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
         .contains("\r     1. A line\n\r     2. Another line"));
@@ -311,7 +311,7 @@ fn draw_short_with_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 1;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     // The number of lines is less than 'rows' so 'upper_mark' will be 0 even
     // if we set it to 1. This is done because everything can be displayed without problems.
@@ -333,7 +333,7 @@ fn draw_long_with_line_numbers() {
     pager.line_numbers = LineNumbers::Enabled;
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -344,7 +344,7 @@ fn draw_long_with_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 1;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -356,7 +356,7 @@ fn draw_long_with_line_numbers() {
     let mut out = Vec::with_capacity(lines.len());
     pager.upper_mark = 3;
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
@@ -381,7 +381,7 @@ fn draw_big_line_numbers_are_padded() {
     pager.line_numbers = LineNumbers::Enabled;
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     // The padding should have inserted a space before the numbers that are less than 100.
     assert!(String::from_utf8(out)
@@ -408,7 +408,7 @@ fn draw_wrapping_line_numbers() {
     pager.line_numbers = LineNumbers::Enabled;
     pager.format_lines();
 
-    assert!(draw(&mut out, &mut pager).is_ok());
+    assert!(draw_full(&mut out, &mut pager).is_ok());
 
     let written = String::from_utf8(out).expect("Should have written valid UTF-8");
     let expected = "     2. Line 1: This is the\n\r        line who is 1\n\r     3. Line 2: This is the\n\r        line who is 2";
@@ -425,7 +425,7 @@ fn draw_help_message() {
     pager.line_numbers = LineNumbers::AlwaysOff;
     pager.format_prompt();
 
-    draw(&mut out, &mut pager).expect("Should have written");
+    draw_full(&mut out, &mut pager).expect("Should have written");
 
     let res = String::from_utf8(out).expect("Should have written valid UTF-8");
     assert!(res.contains("minus"));
@@ -438,7 +438,7 @@ fn test_draw_no_overflow() {
     let mut pager = PagerState::new().unwrap();
     pager.lines = TEXT.to_string();
     pager.format_lines();
-    draw(&mut out, &mut pager).unwrap();
+    draw_full(&mut out, &mut pager).unwrap();
     assert!(String::from_utf8(out)
         .expect("Should have written valid UTF-8")
         .contains(TEXT));

--- a/src/core/display/tests.rs
+++ b/src/core/display/tests.rs
@@ -472,7 +472,7 @@ mod draw_for_change_tests {
     }
 
     #[test]
-    fn small_jump() {
+    fn small_scrolldown() {
         let mut ps = create_pager_state();
         let mut out = Vec::with_capacity(100);
 
@@ -496,12 +496,72 @@ mod draw_for_change_tests {
     }
 
     #[test]
-    fn large_jump() {
+    fn large_scrolldown() {
         let mut ps = create_pager_state();
         let mut out = Vec::with_capacity(100);
 
         let mut res = Vec::new();
-        write!(res, "{}{}", MoveTo(0, 0), Clear(ClearType::All)).unwrap();
+        write!(
+            res,
+            "{}{}{}",
+            ScrollUp(9),
+            MoveTo(0, 0),
+            Clear(ClearType::CurrentLine)
+        )
+        .unwrap();
+        for line in &ps.formatted_lines[50..59] {
+            writeln!(res, "\r{}", line).unwrap();
+        }
+        write_prompt(&mut res, &ps.displayed_prompt, ps.rows as u16).unwrap();
+
+        draw_for_change(&mut out, &mut ps, &mut 50).unwrap();
+
+        assert_eq!(out, res);
+    }
+
+    #[test]
+    fn no_overflow_change() {
+        let mut ps = create_pager_state();
+        ps.formatted_lines.truncate(5);
+        let mut out = Vec::with_capacity(100);
+        let mut new_upper_mark = 10;
+
+        let res = Vec::new();
+
+        draw_for_change(&mut out, &mut ps, &mut new_upper_mark).unwrap();
+
+        assert_eq!(out, res);
+    }
+
+    #[test]
+    fn large_scrollup() {
+        let mut ps = create_pager_state();
+        let mut out = Vec::with_capacity(100);
+        ps.upper_mark = 80;
+
+        let mut res = Vec::new();
+        write!(res, "{}{}", ScrollDown(9), MoveTo(0, 0),).unwrap();
+        for line in &ps.formatted_lines[20..29] {
+            writeln!(res, "\r{}", line).unwrap();
+        }
+        write_prompt(&mut res, &ps.displayed_prompt, ps.rows as u16).unwrap();
+
+        draw_for_change(&mut out, &mut ps, &mut 20).unwrap();
+
+        dbg!(String::from_utf8_lossy(&out));
+        dbg!(String::from_utf8_lossy(&res));
+
+        assert_eq!(out, res);
+    }
+
+    #[test]
+    fn small_scrollup() {
+        let mut ps = create_pager_state();
+        let mut out = Vec::with_capacity(100);
+        ps.upper_mark = 60;
+
+        let mut res = Vec::new();
+        write!(res, "{}{}", ScrollDown(9), MoveTo(0, 0),).unwrap();
         for line in &ps.formatted_lines[50..59] {
             writeln!(res, "\r{}", line).unwrap();
         }

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 use std::sync::{atomic::AtomicBool, Arc};
 
+use super::display;
 #[cfg(feature = "search")]
 use super::search;
 use super::{events::Event, term};
@@ -36,7 +37,10 @@ pub fn handle_event(
             is_exitted.store(true, std::sync::atomic::Ordering::SeqCst);
             term::cleanup(&mut out, &p.exit_strategy, true)?;
         }
-        Event::UserInput(InputEvent::UpdateUpperMark(um)) => p.upper_mark = um,
+        Event::UserInput(InputEvent::UpdateUpperMark(mut um)) => {
+            display::draw_for_change(out, p, &mut um)?;
+            p.upper_mark = um;
+        }
         Event::UserInput(InputEvent::RestorePrompt) => {
             // Set the message to None and new messages to false as all messages have been shown
             p.message = None;

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -63,6 +63,11 @@ impl Event {
         matches!(self, Self::UserInput(InputEvent::Exit))
     }
 
+    #[allow(dead_code)]
+    pub(crate) const fn is_movement(&self) -> bool {
+        matches!(self, Self::UserInput(InputEvent::UpdateUpperMark(_)))
+    }
+
     #[cfg(feature = "dynamic_output")]
     pub(crate) const fn required_immidiate_screen_update(&self) -> bool {
         matches!(

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -8,7 +8,7 @@
 //! * The [`start_reactor`] function displays the displays the output and also polls
 //! the [`Receiver`] held inside the [`Pager`] for events. Whenever a event is
 //! detected, it reacts to it accordingly.
-use super::{display::draw, ev_handler::handle_event, events::Event, term};
+use super::{display::draw_full, ev_handler::handle_event, events::Event, term};
 use crate::{error::MinusError, input::InputEvent, Pager, PagerState};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
@@ -186,7 +186,7 @@ fn start_reactor(
     let mut out_lock = out.lock();
 
     if let Ok(mut p) = ps.lock() {
-        draw(&mut out_lock, &mut p)?;
+        draw_full(&mut out_lock, &mut p)?;
     }
 
     #[allow(clippy::match_same_arms)]
@@ -219,7 +219,7 @@ fn start_reactor(
                         input_thread_running,
                     )?;
                     if !is_exit_event || !is_movement {
-                        draw(&mut out_lock, &mut p)?;
+                        draw_full(&mut out_lock, &mut p)?;
                     }
                 }
                 Ok(Event::SetPrompt(ref text) | Event::SendMessage(ref text)) => {
@@ -300,7 +300,7 @@ fn start_reactor(
                     break;
                 }
                 if !is_movement {
-                    draw(&mut out_lock, &mut p)?;
+                    draw_full(&mut out_lock, &mut p)?;
                 }
             }
         },

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -286,6 +286,7 @@ fn start_reactor(
         #[cfg(feature = "static_output")]
         Some(&RunMode::Static) => loop {
             if let Ok(Event::UserInput(inp)) = rx.recv() {
+                let is_movement = Event::UserInput(inp).is_movement();
                 let mut p = ps.lock().unwrap();
                 handle_event(
                     Event::UserInput(inp),
@@ -298,7 +299,9 @@ fn start_reactor(
                 if is_exitted.load(Ordering::SeqCst) {
                     break;
                 }
-                draw(&mut out_lock, &mut p)?;
+                if !is_movement {
+                    draw(&mut out_lock, &mut p)?;
+                }
             }
         },
         None => panic!("Static variable RUNMODE not set"),

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -9,10 +9,12 @@
 //! the [`Receiver`] held inside the [`Pager`] for events. Whenever a event is
 //! detected, it reacts to it accordingly.
 use super::{display::draw, ev_handler::handle_event, events::Event, term};
-use crate::{error::MinusError, input::InputEvent, Pager, PagerState};
+use crate::{
+    error::MinusError, input::InputEvent, minus_core::term::move_cursor, Pager, PagerState,
+};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
-use crossterm::event;
+use crossterm::{event, queue};
 #[cfg(feature = "dynamic_output")]
 use crossterm::{
     execute,
@@ -207,6 +209,48 @@ fn start_reactor(
 
             #[allow(clippy::unnested_or_patterns)]
             match event {
+                Ok(Event::UserInput(InputEvent::UpdateUpperMark(um))) => {
+                    let lower_bound = p.upper_mark.saturating_add(p.rows).saturating_sub(1);
+
+                    // TODO: Normalize this value using p.row value
+                    let diff = um.abs_diff(p.upper_mark);
+
+                    let lines = p.get_flattened_lines_with_bounds(
+                        lower_bound,
+                        lower_bound.saturating_add(diff),
+                    );
+
+                    if um > p.upper_mark {
+                        queue!(
+                            out_lock,
+                            crossterm::terminal::ScrollUp(diff.try_into().unwrap())
+                        )?;
+                        move_cursor(
+                            &mut out_lock,
+                            0,
+                            p.rows.saturating_sub(diff + 1).try_into().unwrap(),
+                            false,
+                        )?;
+                        for line in lines {
+                            execute!(out_lock, Clear(ClearType::CurrentLine))?;
+                            write!(out_lock, "\r{}", line)?;
+                        }
+                        super::display::write_prompt(
+                            &mut out_lock,
+                            &p.displayed_prompt,
+                            p.rows.try_into().unwrap(),
+                        )?;
+                        out_lock.flush()?;
+                        p.upper_mark = p.upper_mark.saturating_add(diff);
+                    } else if um < p.upper_mark {
+                        execute!(
+                            out_lock,
+                            crossterm::terminal::ScrollDown(diff.try_into().unwrap())
+                        )?;
+                        p.upper_mark = p.upper_mark.saturating_sub(diff);
+                    }
+                }
+
                 Ok(ev) if ev.required_immidiate_screen_update() => {
                     let is_exit_event = ev.is_exit_event();
                     handle_event(

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -9,7 +9,7 @@
 //! the [`Receiver`] held inside the [`Pager`] for events. Whenever a event is
 //! detected, it reacts to it accordingly.
 use super::{display::draw, ev_handler::handle_event, events::Event, term};
-use crate::{error::MinusError, input::InputEvent, minus_core::display, Pager, PagerState};
+use crate::{error::MinusError, input::InputEvent, Pager, PagerState};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossterm::event;
@@ -207,13 +207,9 @@ fn start_reactor(
 
             #[allow(clippy::unnested_or_patterns)]
             match event {
-                Ok(Event::UserInput(InputEvent::UpdateUpperMark(mut um))) => {
-                    display::draw2(&mut out_lock, &mut p, &mut um)?;
-                    p.upper_mark = um;
-                }
-
                 Ok(ev) if ev.required_immidiate_screen_update() => {
                     let is_exit_event = ev.is_exit_event();
+                    let is_movement = ev.is_movement();
                     handle_event(
                         ev,
                         &mut out_lock,
@@ -222,7 +218,7 @@ fn start_reactor(
                         #[cfg(feature = "search")]
                         input_thread_running,
                     )?;
-                    if !is_exit_event {
+                    if !is_exit_event || !is_movement {
                         draw(&mut out_lock, &mut p)?;
                     }
                 }


### PR DESCRIPTION
The following set of changes will enable minus to calculate what lines need to be redrawn after a user scrolls up or down and only change those lines.

This means that there will be no complete redraws of the terminal unless it's necessary. This will cause much faster display output for larger terminal windows and monitors and also improves the overall performance of minus

I am unsure of the overall roadmap but I will still keep one here as I share my progress on this 

## Overall Roadmap
- [x] Do less redraw on single scroll down
- [x] Less redraw for scroll up
- [x] Explore optimisations that can be made
- [x] Write tests
- [x] Support for static output
- [x] Write documentation