### PR TITLE
fix(state): compile error due to message being private

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -53,7 +53,7 @@ pub struct PagerState {
     /// Any message to display to the user at the prompt
     /// The first element contains the actual message, while the second element tells
     /// whether the message has changed since the last display.
-    pub(crate) message: Option<String>,
+    pub message: Option<String>,
     /// The prompt that should be displayed to the user, formatted with the
     /// current search index and number of matches (if the search feature is enabled),
     /// and the current numbers inputted to scroll


### PR DESCRIPTION
End applications failed to compile when they copy pasted the default input::DefaultInputClassifier as the PagerState::message was not available at the public scope.

This patch fixes this by setting the item's scope to public

Closes #90