### PR TITLE
Fix no updatation of prompt status when jumping through search matches 

### DIFF
--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -96,6 +96,7 @@ pub fn handle_event(
         {
             // Go to the next match
             search::next_nth_match(p, 1);
+            p.format_prompt();
         }
         #[cfg(feature = "search")]
         Event::UserInput(InputEvent::PrevMatch | InputEvent::MoveToPrevMatch(1))
@@ -119,6 +120,7 @@ pub fn handle_event(
         Event::UserInput(InputEvent::MoveToNextMatch(n)) if p.search_term.is_some() => {
             // Go to the next match
             search::next_nth_match(p, n.saturating_sub(1));
+            p.format_prompt();
         }
         #[cfg(feature = "search")]
         Event::UserInput(InputEvent::MoveToPrevMatch(n)) if p.search_term.is_some() => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,16 +177,16 @@
 //! | Action            | Description                                                                                                               |
 //! |-------------------|---------------------------------------------------------------------------------------------------------------------------|
 //! | Ctrl+C/q          | Quit the pager                                                                                                            |
-//! | \[n\] Arrow Up/k    | Scroll up by n number of line(s). If n is omitted, scroll up by 1 line                                                    |
-//! | \[n\] Arrow Down/j  | Scroll down by n number of line(s). If n is omitted, scroll down by 1 line                                                |
+//! | \[n\] Arrow Up/k  | Scroll up by n number of line(s). If n is omitted, scroll up by 1 line                                                    |
+//! | \[n\] Arrow Down/j| Scroll down by n number of line(s). If n is omitted, scroll down by 1 line                                                |
 //! | Page Up           | Scroll up by entire page                                                                                                  |
 //! | Page Down         | Scroll down by entire page                                                                                                |
-//! | \[n\] Enter         | Scroll down by n number of line(s). If n is omitted, scroll by 1 line. If there are prompt messages, this will clear them |
+//! | \[n\] Enter       | Scroll down by n number of line(s). If n is omitted, scroll by 1 line. If there are prompt messages, this will clear them |
 //! | Space             | Scroll down by one page                                                                                                   |
 //! | Ctrl+U/u          | Scroll up by half a screen                                                                                                |
 //! | Ctrl+D/d          | Scroll down by half a screen                                                                                              |
 //! | g                 | Go to the very top of the output                                                                                          |
-//! | \[n\] G             | Go to the very bottom of the output. If n is present, goes to that line                                                   |
+//! | \[n\] G           | Go to the very bottom of the output. If n is present, goes to that line                                                   |
 //! | Mouse scroll Up   | Scroll up by 5 lines                                                                                                      |
 //! | Mouse scroll Down | Scroll down by 5 lines                                                                                                    |
 //! | Ctrl+L            | Toggle line numbers if not forced enabled/disabled                                                                        |


### PR DESCRIPTION
This bug resulted in prompt text to not be updated when moving to pext search. This is easily solved by asking the prompt text to be regenerated.