### PR TITLE
Placate `typos`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,23 @@ This file documents all changes made to the project and is updated before each r
 * Pressing `[n]G` takes to nth row on screen rather than the nth line in the actual text (#99)
 
 ### Changed
-* `HashedInputRegister::default()` now inserts the defualt bindings before returning the `HashedInputRegister`.
+* `HashedInputRegister::default()` now inserts the default bindings before returning the `HashedInputRegister`.
     This better aligns with the docs.
 * Massively simplify all the text-related functions and add better docs to all of them. (#97)
 
 ### Added
 * `HashedInputRegister::new()` is now publicly available
-* Added `HashedInputRegister::with_default_hasher()` to create a `HashedInoutRegister` with the default hasher.
-* Added a `Dockerfile` to build/test minus in isolated enviroment.
+* Added `HashedInputRegister::with_default_hasher()` to create a `HashedInputRegister` with the default hasher.
+* Added a `Dockerfile` to build/test minus in isolated environment.
 
 ## v5.3.1 [2023-05-02]
 ### Fixed
-* Passing `false` to PagerStae::set_run_no_overflow() causes a full
+* Passing `false` to PagerState::set_run_no_overflow() causes a full
   pager to start where in reality passing `true` should lead to this
   action. (#94)
 * If a full pager isn't started in static output mode and another pager
   is started after the first one, minus would make a panic as the
-  `RUNMODE` variable dosen't get reset. This patch also fixes this bug. (#94)
+  `RUNMODE` variable doesn't get reset. This patch also fixes this bug. (#94)
 
 ## v5.3.0 [2023-04-10]
 ### Added
@@ -118,16 +118,16 @@ This file documents all changes made to the project and is updated before each r
 
 - Fixed mouse scroll wheel not scrolling through the screen.
 
-   This occured because a of a previous patch which removed the line that enabled the mouse events to be captured.
+   This occurred because a of a previous patch which removed the line that enabled the mouse events to be captured.
  
 * Fix panic when the search term gets changed
 
-  This occured due to the `search_idx` not being repopulated when a new search is activated.
+  This occurred due to the `search_idx` not being repopulated when a new search is activated.
 
 ## v5.0.1 [2022-03-20]
 * Fixed extremely high CPU usage while running caused due to calling `Receiver::try_recv()` rather than
   `Receiver::recv()`(#60)
-* Fixed another performace bug which was due to calling `event::poll` every 10ms. The poll duration
+* Fixed another performance bug which was due to calling `event::poll` every 10ms. The poll duration
   was increased to 100ms without any loss of responsiveness (9f7dace34)
 * Changed initialization of some fields in `PagerState` tp preallocate memory for them. This reduces
   the number of allocations that need to be made when the pager just starts.
@@ -156,7 +156,7 @@ This file documents all changes made to the project and is updated before each r
 
 * Store the current run mode as static value
 
-  * The `RUNMODE` static item tells minus whether it is running in static mode or asynchonous mode
+  * The `RUNMODE` static item tells minus whether it is running in static mode or asynchronous mode
   * Added `once_cell` as a dependency to store the above value in static scope.
   
 * Added feature to scroll through more than one line
@@ -170,7 +170,7 @@ This file documents all changes made to the project and is updated before each r
   (#57)
     
 * Added a `PagerState` struct to store and share internal data. It is made public, along with some of its
-fields so that it can be used to implement `InputClassifer` trait for applications that want to modify the
+fields so that it can be used to implement `InputClassifier` trait for applications that want to modify the
 default keybindings
 
 * Renamed `AlternatePagingError` to `MinusError`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributing to a `minus` is pretty straight forward. If this is you're first ti
 - Create an issue describing your feature/bug/enhancement and how it will be beneficial.
 - State that you are currently working on implementing/fixing the feature/bug/enhancement
 - Fork this repo.
-- Start from **main** branch and create a seperate branch for making changes.
+- Start from **main** branch and create a separate branch for making changes.
 - Read the code available and make your changes.
 - When you're done, submit a pull request for one of the maintainers to check it out. We would let you know if there is
   any problem or any changes that should be considered.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ async fn main() -> Result<(), MinusError> {
     let pager = pager.clone();
     let (res1, res2) = join!(spawn_blocking(move || dynamic_paging(pager)), increment);
     // .unwrap() unwraps any error while creating the tokio task
-    //  The ? mark unpacks any error that might have occured while the
+    //  The ? mark unpacks any error that might have occurred while the
     // pager is running
     res1.unwrap()?;
     res2?;
@@ -182,7 +182,7 @@ assumed that text data will not change.
 
 Here is the list of default key/mouse actions handled by `minus`.
 
-**A `[n] key` means that you can preceed the key by a integer**. 
+**A `[n] key` means that you can precede the key by a integer**. 
 
 | Action            | Description                                                                                                               |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------|

--- a/examples/less-rs.rs
+++ b/examples/less-rs.rs
@@ -4,7 +4,7 @@
 
 // This example uses a lot of `.expect()` and does not properly handle them. If
 // someone is interested to add proper error handling, you are free to file pull
-//requests. Libraries like anyhow and thiserror are generally prefered and minus
+//requests. Libraries like anyhow and thiserror are generally preferred and minus
 //also uses thiserror
 
 use std::env::args;

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -25,7 +25,7 @@ pub fn handle_event(
     ev: Event,
     mut out: &mut impl Write,
     p: &mut PagerState,
-    is_exitted: &Arc<AtomicBool>,
+    is_exited: &Arc<AtomicBool>,
     #[cfg(feature = "search")] user_input_active: &Arc<(Mutex<bool>, Condvar)>,
 ) -> Result<(), MinusError> {
     match ev {
@@ -35,7 +35,7 @@ pub fn handle_event(
         }
         Event::UserInput(InputEvent::Exit) => {
             p.exit();
-            is_exitted.store(true, std::sync::atomic::Ordering::SeqCst);
+            is_exited.store(true, std::sync::atomic::Ordering::SeqCst);
             term::cleanup(&mut out, &p.exit_strategy, true)?;
         }
         Event::UserInput(InputEvent::UpdateUpperMark(mut um)) => {
@@ -80,7 +80,7 @@ pub fn handle_event(
             if let Some(incremental_search_result) = search_result.incremental_search_result {
                 p.search_term = search_result.compiled_regex;
                 p.upper_mark = incremental_search_result.upper_mark;
-                p.search_mark = incremental_search_result.searh_mark;
+                p.search_mark = incremental_search_result.search_mark;
                 p.search_idx = incremental_search_result.search_idx;
                 p.formatted_lines = incremental_search_result.formatted_lines;
                 return Ok(());
@@ -136,7 +136,7 @@ pub fn handle_event(
             if p.search_idx.is_empty() {
                 return Ok(());
             }
-            // Decrement the s_mark and get the preceeding index
+            // Decrement the s_mark and get the preceding index
             p.search_mark = p.search_mark.saturating_sub(1);
             if let Some(y) = p.search_idx.iter().nth(p.search_mark) {
                 // If the index is less than or equal to the upper_mark, then set y to the new upper_mark
@@ -154,7 +154,7 @@ pub fn handle_event(
                 p.search_mark = pnm;
                 p.upper_mark = *p.search_idx.iter().nth(p.search_mark).unwrap();
 
-                // Ensure there is enough text available after location coresponding to
+                // Ensure there is enough text available after location corresponding to
                 // position_of_next_match so that we can display a pagefull of data. If not,
                 // reduce it so that a pagefull of text can be accommodated.
                 // NOTE: Add 1 to total number of lines to avoid off-by-one errors
@@ -171,7 +171,7 @@ pub fn handle_event(
             if p.search_idx.is_empty() {
                 return Ok(());
             }
-            // Decrement the s_mark and get the preceeding index
+            // Decrement the s_mark and get the preceding index
             p.search_mark = p.search_mark.saturating_sub(n);
             if let Some(y) = p.search_idx.iter().nth(p.search_mark) {
                 // If the index is less than or equal to the upper_mark, then set y to the new upper_mark
@@ -222,7 +222,7 @@ pub fn handle_event(
         #[cfg(feature = "static_output")]
         Event::SetRunNoOverflow(val) => p.run_no_overflow = val,
         #[cfg(feature = "search")]
-        Event::IncrementalSearchCondition(cb) => p.incremental_search_condtion = cb,
+        Event::IncrementalSearchCondition(cb) => p.incremental_search_condition = cb,
         Event::SetInputClassifier(clf) => p.input_classifier = clf,
         Event::AddExitCallback(cb) => p.exit_callbacks.push(cb),
         Event::UserInput(_) => {}

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -79,7 +79,7 @@ impl Event {
     }
 
     #[cfg(feature = "dynamic_output")]
-    pub(crate) const fn required_immidiate_screen_update(&self) -> bool {
+    pub(crate) const fn required_immediate_screen_update(&self) -> bool {
         matches!(
             self,
             Self::SetData(_) | Self::SetPrompt(_) | Self::SendMessage(_) | Self::UserInput(_)

--- a/src/core/utils/display/mod.rs
+++ b/src/core/utils/display/mod.rs
@@ -36,7 +36,7 @@ pub fn draw_for_change(
     let lower_bound = p.upper_mark.saturating_add(writable_rows.min(line_count));
     let new_lower_bound = new_upper_mark.saturating_add(writable_rows.min(line_count));
 
-    // If the lower_bound is greater than the avilable line count, we set it to such a value
+    // If the lower_bound is greater than the available line count, we set it to such a value
     // so that the last page can be displayed entirely, i.e never scroll past the last line
     if new_lower_bound > line_count {
         *new_upper_mark = line_count.saturating_sub(writable_rows);
@@ -128,12 +128,12 @@ pub fn write_prompt(out: &mut impl Write, text: &str, rows: u16) -> Result<(), M
 // The below functions are just a subset of functionality of the above draw_for_change function.
 // Although, separate they are tightly coupled together.
 
-/// Completely redraws the scrren
+/// Completely redraws the screen
 ///
 /// The function will first print out the lines from the current upper_mark. This is handled inside the [`write_lines`]
 /// function.
 ///
-/// Then it wil check if there is any message to display.
+/// Then it will check if there is any message to display.
 ///   - If there is one, it will display it at the prompt site
 ///   - If there isn't one, it will display the prompt in place of it
 pub fn draw_full(out: &mut impl Write, pager: &mut PagerState) -> Result<(), MinusError> {
@@ -212,7 +212,7 @@ pub fn draw_append_text(
 /// [`PagerState::upper_mark`]. This function will always try to display as much lines as
 /// possible within `rows -1`.
 ///
-/// It always skips one row at the botton as a site for the prompt or any message that may be sent.
+/// It always skips one row at the bottom as a site for the prompt or any message that may be sent.
 ///
 /// This function ensures that upper mark never exceeds a value such that adding upper mark and available rows exceeds
 /// the number of lines of text data. This rule is disobeyed in only one special case which is if number of lines of
@@ -232,7 +232,7 @@ pub fn write_text_checked(
     // on the minimality
     let mut lower_mark = upper_mark.saturating_add(writable_rows.min(line_count));
 
-    // If the lower_bound is greater than the avilable line count, we set it to such a value
+    // If the lower_bound is greater than the available line count, we set it to such a value
     // so that the last page can be displayed entirely, i.e never scroll past the last line
     if lower_mark > line_count {
         *upper_mark = line_count.saturating_sub(writable_rows);
@@ -258,7 +258,7 @@ pub fn write_from_pagerstate(out: &mut impl Write, ps: &mut PagerState) -> Resul
     // on the minimality
     let lower_mark = ps.upper_mark.saturating_add(writable_rows.min(line_count));
 
-    // If the lower_bound is greater than the avilable line count, we set it to such a value
+    // If the lower_bound is greater than the available line count, we set it to such a value
     // so that the last page can be displayed entirely, i.e never scroll past the last line
     if lower_mark > line_count {
         ps.upper_mark = line_count.saturating_sub(writable_rows);

--- a/src/core/utils/term.rs
+++ b/src/core/utils/term.rs
@@ -80,7 +80,7 @@ pub fn cleanup(
 
 /// Moves the terminal cursor to given x, y coordinates
 ///
-/// The `flush` parameter will immidiately flush the buffer if it is set to `true`
+/// The `flush` parameter will immediately flush the buffer if it is set to `true`
 pub fn move_cursor(
     out: &mut impl io::Write,
     x: u16,

--- a/src/core/utils/text.rs
+++ b/src/core/utils/text.rs
@@ -1,6 +1,6 @@
 //! Text related functions
 //!
-//! minus has a very intresting but simple text model that you must go through to understand how minus works.
+//! minus has a very interesting but simple text model that you must go through to understand how minus works.
 //!
 //! # Text Block
 //! A text block in minus is just a bunch of text that may contain newlines (`\n`) between them.
@@ -75,7 +75,7 @@ pub struct FormatOpts<'a> {
     pub len_line_number: usize,
     /// Actual number of columns available for displaying
     pub cols: usize,
-    /// Number of lines that are previously unterminated. It is only relevent when there is `attachment` text otherwise
+    /// Number of lines that are previously unterminated. It is only relevant when there is `attachment` text otherwise
     /// it should be 0.
     pub prev_unterminated: usize,
     /// Search term if a search is active
@@ -266,7 +266,7 @@ pub fn format_text_block(mut opts: FormatOpts<'_>) -> FormatResult {
             .collect();
     }
 
-    // Calculate number of rows which are part of last line and are left unterminated  due to absense of \n
+    // Calculate number of rows which are part of last line and are left unterminated  due to absence of \n
     let unterminated = if opts.text.ends_with('\n') {
         // If the last line ends with \n, then the line is complete so nothing is left as unterminated
         0
@@ -305,7 +305,7 @@ pub fn format_text_block(mut opts: FormatOpts<'_>) -> FormatResult {
 /// - `formatted_idx`: is the position index where the line will be placed in the resulting
 ///    [`PagerState::formatted_lines`](crate::state::PagerState::formatted_lines)
 /// - `cols`: Number of columns in the terminal
-/// - `search_term`: Contains the regex iif a search is active
+/// - `search_term`: Contains the regex if a search is active
 ///
 /// [`PagerState::lines`]: crate::state::PagerState::lines
 #[allow(clippy::too_many_arguments)]
@@ -328,8 +328,8 @@ pub fn formatted_line(
     // Whether line numbers are active
     let line_numbers = matches!(line_numbers, LineNumbers::Enabled | LineNumbers::AlwaysOn);
 
-    // NOTE: Only relevent when line numbers are active
-    // Padding is the space that the actual line text will be shifted to accomodate for
+    // NOTE: Only relevant when line numbers are active
+    // Padding is the space that the actual line text will be shifted to accommodate for
     // line numbers. This is equal to:-
     // LineNumbers::EXTRA_PADDING + len_line_number + 1 (for '.')
     //

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use crate::minus_core::events::Event;
 
 /// An operation on the terminal failed, for example resizing it.
 ///
-/// You can get more informations about this error by calling
+/// You can get more information about this error by calling
 /// [`source`](std::error::Error::source) on it.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
@@ -109,7 +109,7 @@ pub enum MinusError {
     JoinError(#[from] tokio::task::JoinError),
 }
 
-// Just for  convinience helper which is useful in many places
+// Just for  convenience helper which is useful in many places
 #[cfg(feature = "search")]
 impl From<regex::Error> for MinusError {
     fn from(e: regex::Error) -> Self {

--- a/src/input/event_wrapper.rs
+++ b/src/input/event_wrapper.rs
@@ -84,7 +84,7 @@ use std::{
 
 pub struct HashedEventRegister<S>(HashMap<EventWrapper, EventReturnType, S>);
 
-/// A convinient type for the return type of [`HashedEventRegister::get`]
+/// A convenient type for the return type of [`HashedEventRegister::get`]
 type EventReturnType = Arc<dyn Fn(Event, &PagerState) -> InputEvent + Send + Sync>;
 
 #[derive(Clone, Eq)]
@@ -164,7 +164,7 @@ where
     /// called when no event matches the incoming event, then we just match whether the event is a keyboard number and
     /// perform the required action.
     ///
-    /// This is also helpful when you nedd to do some action, like sending a message when the user presses wrong
+    /// This is also helpful when you need to do some action, like sending a message when the user presses wrong
     /// keyboard/mouse buttons.
     pub fn insert_wild_event_matcher(
         &mut self,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,6 @@
 //! Working with user events
 //!
-//! This module provides various items for wroking with user events from the terminal.
+//! This module provides various items for working with user events from the terminal.
 //!
 //! minus already has a sensible set of default key/mouse bindings so most people do not need to care about this module.
 //! But if you want to add or remove certain key bindings then you need to rely on this module..
@@ -32,7 +32,7 @@
 //! This method relies heavily on the [`InputClassifier`] trait and the end-applications needs to bring in the underlying
 //! [`crossterm`] crate to define the inputs.
 //! Also there is no such option to add/remove/update a set of events. You need to manually copy the
-//! [default definitions](DefaultInputClassifier) and make the required modifications youself in this method.
+//! [default definitions](DefaultInputClassifier) and make the required modifications yourself in this method.
 //!
 //! ## Example
 //! ```

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -5,7 +5,7 @@ use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
 };
 
-// Just a transparent function to fix incompatiblity issues between
+// Just a transparent function to fix incompatibility issues between
 // versions
 // TODO: Remove this later in favour of how handle_event should actually be called
 fn handle_input(ev: Event, p: &PagerState) -> Option<InputEvent> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@
 //!     let pager = pager.clone();
 //!     let (res1, res2) = join!(spawn_blocking(move || dynamic_paging(pager)), increment);
 //!     // .unwrap() unwraps any error while creating the tokio task
-//!     //  The ? mark unpacks any error that might have occured while the
+//!     //  The ? mark unpacks any error that might have occurred while the
 //!     // pager is running
 //!     res1.unwrap()?;
 //!     res2?;
@@ -183,7 +183,7 @@
 //!
 //! Here is the list of default key/mouse actions handled by `minus`.
 //!
-//! **A `[n] key` means that you can preceed the key by a integer**.
+//! **A `[n] key` means that you can precede the key by a integer**.
 //!
 //! | Action            | Description                                                                                                               |
 //! |-------------------|---------------------------------------------------------------------------------------------------------------------------|
@@ -263,12 +263,12 @@ pub type ExitCallbacks = Vec<Box<dyn FnMut() + Send + Sync + 'static>>;
 /// Result type returned by most minus's functions
 type Result<T = (), E = MinusError> = std::result::Result<T, E>;
 
-/// Behaviour that happens when the pager is exitted
+/// Behaviour that happens when the pager is exited
 #[derive(PartialEq, Clone, Debug, Eq)]
 pub enum ExitStrategy {
     /// Kill the entire application immediately.
     ///
-    /// This is the prefered option if paging is the last thing you do. For example,
+    /// This is the preferred option if paging is the last thing you do. For example,
     /// the last thing you do in your program is reading from a file or a database and
     /// paging it concurrently
     ///
@@ -276,7 +276,7 @@ pub enum ExitStrategy {
     ProcessQuit,
     /// Kill the pager only.
     ///
-    /// This is the prefered option if you want to do more stuff after exiting the pager. For example,
+    /// This is the preferred option if you want to do more stuff after exiting the pager. For example,
     /// if you've file system locks or you want to close database connectiions after
     /// the pager has done i's job, you probably want to go for this option
     PagerQuit,

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -13,7 +13,7 @@ use crate::search::SearchOpts;
 /// is called, the function takes the input. wraps it in the appropriate event
 /// type and transmits it through the sender held inside the this.
 ///
-/// The receiver part of the channel is continously polled by the pager for events. Depending
+/// The receiver part of the channel is continuously polled by the pager for events. Depending
 /// on the type of event that occurs, the pager will either redraw the screen or update
 /// the [PagerState](crate::state::PagerState)
 #[derive(Clone)]
@@ -197,9 +197,9 @@ impl Pager {
         Ok(self.tx.send(Event::SetRunNoOverflow(val))?)
     }
 
-    /// Set a custom input classifer function.
+    /// Set a custom input classifier function.
     ///
-    /// When the pager encounters a user input, it calls the input classifer with
+    /// When the pager encounters a user input, it calls the input classifier with
     /// the event and [PagerState](crate::state::PagerState) as parameters.
     ///
     /// A input classifier is a type implementing the [`InputClassifier`](input::InputClassifier)
@@ -247,7 +247,7 @@ impl Pager {
 
     /// Override the condition for running incremental search
     ///
-    /// See [Incrmental Search](../search/index.html#incremental-search) to know more on how this
+    /// See [Incremental Search](../search/index.html#incremental-search) to know more on how this
     /// works
     ///
     /// # Errors

--- a/src/search.rs
+++ b/src/search.rs
@@ -23,10 +23,10 @@
 //! query is greater than 1 and number of screen lines (lines obtained after taking care of wrapping,
 //! mapped to a single row on the terminal) is greater than 5000.
 //!
-//! Applications can override this condtion with the help of
+//! Applications can override this condition with the help of
 //! [`Pager::set_incremental_search_condition`](crate::pager::Pager::set_incremental_search_condition) function.
 //!
-//! Here is a an example to demonstrate on its usage. Here we set the conditon to run incremental
+//! Here is a an example to demonstrate on its usage. Here we set the condition to run incremental
 //! search only when the length of the search query is greater than 1.
 //! ```
 //! use minus::{Pager, search::SearchOpts};
@@ -107,7 +107,7 @@ impl PartialEq for SearchMode {
 
 /// Options controlling the behaviour of search overall
 ///
-/// Although it isn't much important for most use cases but it alongside [IncrementalSearchOpts] are the key compoents
+/// Although it isn't much important for most use cases but it alongside [IncrementalSearchOpts] are the key components
 /// when applications want to customize the incremental seaech condition.
 ///
 /// Most of the fields have self-explanatory names so it should be very easy to get started using
@@ -255,7 +255,7 @@ pub(crate) struct IncrementalSearchCache {
     pub(crate) formatted_lines: Vec<String>,
     /// Index from `search_idx` where a search match after current upper mark may be found
     /// NOTE: There is no guarantee that this will stay within the bounds of `search_idx`
-    pub(crate) searh_mark: usize,
+    pub(crate) search_mark: usize,
     /// Indices of formatted_lines where search matches have been found
     pub(crate) search_idx: BTreeSet<usize>,
     /// Index of the line from which to display the text.
@@ -339,7 +339,7 @@ where
     let mut upper_mark;
     if let Some(pnm) = position_of_next_match {
         upper_mark = *format_result.append_search_idx.iter().nth(pnm).unwrap();
-        // Draw the icrementally searched lines from upper mark
+        // Draw the incrementally searched lines from upper mark
         display::write_text_checked(out, &format_result.lines, so.rows.into(), &mut upper_mark)?;
     } else {
         reset_screen(out, so)?;
@@ -349,7 +349,7 @@ where
     // cache.
     Ok(Some(IncrementalSearchCache {
         formatted_lines: format_result.lines,
-        searh_mark: position_of_next_match.unwrap(),
+        search_mark: position_of_next_match.unwrap(),
         upper_mark,
         search_idx: format_result.append_search_idx,
     }))
@@ -538,7 +538,7 @@ where
 
         Event::Key(event) => {
             // For any character key, without a modifier, insert it into so.string before
-            // current cursor positon and update the line
+            // current cursor position and update the line
             if let KeyCode::Char(c) = event.code {
                 so.string
                     .insert(so.cursor_position.saturating_sub(1).into(), c);
@@ -596,7 +596,7 @@ pub(crate) fn fetch_input(
         if event::poll(Duration::from_millis(100)).map_err(|e| MinusError::HandleEvent(e.into()))? {
             let ev = event::read().map_err(|e| MinusError::HandleEvent(e.into()))?;
             search_opts.ev = Some(ev);
-            handle_key_press(out, &mut search_opts, &ps.incremental_search_condtion)?;
+            handle_key_press(out, &mut search_opts, &ps.incremental_search_condition)?;
             search_opts.ev = None;
         }
         if search_opts.input_status.done() {
@@ -611,7 +611,7 @@ pub(crate) fn fetch_input(
     let fetch_input_result = match search_opts.input_status {
         InputStatus::Active => unreachable!(),
         InputStatus::Cancelled => FetchInputResult::new_empty(),
-        // When thw query is confirmed, return the actual query along with everything that is valid
+        // When the query is confirmed, return the actual query along with everything that is valid
         // in the cache
         InputStatus::Confirmed => FetchInputResult {
             string: search_opts.string,
@@ -739,7 +739,7 @@ pub(crate) fn next_nth_match(
             *i > upper_mark
         }
     }) {
-        // This ensures that index dosen't get off-by-one in case of jump = 0
+        // This ensures that index doesn't get off-by-one in case of jump = 0
         if jump == 0 {
             position_of_next_match = nearest_idx;
         } else {
@@ -881,7 +881,7 @@ mod tests {
 
             // Check functionality of left arrow key
             // Pressing left arrow moves the cursor towards the beginning of string until it
-            // reaches the first char after which pressing it furthur would not have any effect
+            // reaches the first char after which pressing it further would not have any effect
             for i in (FIRST_MOVABLE_COLUMN..=query_string_length).rev() {
                 search_opts.ev = Some(make_event_from_keycode(KeyCode::Left));
                 handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
@@ -903,7 +903,7 @@ mod tests {
 
             // Check functionality of right arrow key
             // Pressing right arrow moves the cursor towards the end of string until it
-            // reaches the very next column to the last char after which pressing it furthur would not have any effect
+            // reaches the very next column to the last char after which pressing it further would not have any effect
             for i in 2..=last_movable_column {
                 search_opts.ev = Some(make_event_from_keycode(KeyCode::Right));
                 handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();

--- a/src/state.rs
+++ b/src/state.rs
@@ -69,7 +69,7 @@ pub struct PagerState {
     pub cols: usize,
     /// This variable helps in scrolling more than one line at a time
     /// It keeps track of all the numbers that have been entered by the user
-    /// untill any of `j`, `k`, `G`, `Up` or `Down` is pressed
+    /// until any of `j`, `k`, `G`, `Up` or `Down` is pressed
     pub prefix_num: String,
     /// Describes whether minus is running and in which mode
     pub running: &'static Mutex<crate::RunMode>,
@@ -113,7 +113,7 @@ pub struct PagerState {
     /// See [`input::generate_default_bindings`] for exact definition on how it is implemented.
     pub(crate) lines_to_row_map: HashMap<usize, usize>,
     #[cfg(feature = "search")]
-    pub(crate) incremental_search_condtion:
+    pub(crate) incremental_search_condition:
         Box<dyn Fn(&SearchOpts) -> bool + Send + Sync + 'static>,
 }
 
@@ -147,7 +147,7 @@ impl PagerState {
             .unwrap_or_else(|_| String::from("minus"));
 
         #[cfg(feature = "search")]
-        let incremental_search_condtion = Box::new(|so: &SearchOpts| {
+        let incremental_search_condition = Box::new(|so: &SearchOpts| {
             so.string.len() > 1
                 && so
                     .incremental_search_options
@@ -182,7 +182,7 @@ impl PagerState {
             #[cfg(feature = "search")]
             search_mark: 0,
             #[cfg(feature = "search")]
-            incremental_search_condtion,
+            incremental_search_condition,
             // Just to be safe in tests, keep at 1x1 size
             cols,
             rows,

--- a/src/static_pager.rs
+++ b/src/static_pager.rs
@@ -16,7 +16,7 @@ use crate::{error::MinusError, Pager};
 /// * Since any other event except user inputs will not occur, we can do some optimizations on
 /// matching events.
 ///
-/// See [example](../index.html#static-output) on how to use this functon.
+/// See [example](../index.html#static-output) on how to use this function.
 ///
 /// # Panics
 /// This function will panic if another instance of minus is already running.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -243,7 +243,7 @@ fn exit_callback() {
 }
 
 mod emit_events {
-    // Check functions emit correct events on functin calls
+    // Check functions emit correct events on function calls
     use crate::{minus_core::events::Event, ExitStrategy, LineNumbers, Pager};
 
     const TEST_STR: &str = "This is sample text";


### PR DESCRIPTION
I noticed a typo when I was looking at the README of the crate (really cool crate btw! Hope that `bat` ends up using it, but I see you're already working on that). Instead of just fixing that one typo I figured I would go ahead and fix all of the typos that [`typos`](https://github.com/crate-ci/typos) found

Oh I also did a pass over everything and didn't see any changes to the public API, but that could probably use a second pair of eyes