### PR TITLE
Accurate Search Highlights

### DIFF
--- a/src/core/utils/text.rs
+++ b/src/core/utils/text.rs
@@ -353,7 +353,7 @@ pub fn formatted_line(
     let mut handle_search = |row: String, wrap_idx: usize| {
         #[cfg(feature = "search")]
         if let Some(st) = search_term.as_ref() {
-            let (highlighted_row, is_match) = search::highlight_line_matches(&row, st);
+            let (highlighted_row, is_match) = search::highlight_line_matches(&row, st, false);
             if is_match {
                 search_idx.insert(formatted_idx + wrap_idx);
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1179,5 +1179,21 @@ eros.",
                 )
             );
         }
+
+        #[test]
+        fn coorect_ascii_sequence_placement() {
+            let orig = format!("this {ESC}is a te{NONE}st again {ESC}yeah{NONE} test",);
+            let res = highlight_line_matches(&orig, &Regex::new("test").unwrap());
+            assert_eq!(
+                res.0,
+                format!(
+                    "this {e}is a {i}t{NONE}est{n} again {e}yeah{nn} {i}test{n}",
+                    e = ESC,
+                    i = *INVERT,
+                    n = *NORMAL,
+                    nn = NONE
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Right now minus uses a highlighting technique while searching where first removes all ANSI escape sequences from the text data and then a search and then searches the entire text. If a match is found, it places an ANSI `INVERT` sequence right before the match and an ANSI `NORMAL` sequence right after the match. Then it places all the escape sequences that the original text had into the right position. 

Now where this goes wrong is if a match has escape sequence inside it, minus does not place it at that position. This approach brings a more consistent highlighting throughout and makes the text look less funky at the cost of some inaccuracies. But sometimes this cost is unaffordable hence this PR.

With this we plan to further improve the search highlighting technique to where a user has two options:-
- Get accurate search Highlighting which might make the text look funky if the text has placed ANSI escape sequences at weird locations.
- Get a more consistent highlighting at the cost of some minor discrepancies. Although this was already available, it will also be improved overall where rather than ignoring escape sequences at the middle of search matches, it will place them right after where the search match ends.