### PR TITLE
fix(init): Special static_output cases don't work

### DIFF
--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -86,6 +86,13 @@ pub fn init_core(pager: &Pager, rm: RunMode) -> std::result::Result<(), MinusErr
     #[allow(unused_mut)]
     let mut ps = crate::state::PagerState::generate_initial_state(&pager.rx, &mut out)?;
 
+    {
+        let mut runmode = super::RUNMODE.lock();
+        assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably because another instance of minus is already running");
+        *runmode = rm;
+        drop(runmode);
+    }
+
     // Static mode checks
     #[cfg(feature = "static_output")]
     if *RUNMODE.lock() == RunMode::Static {
@@ -107,13 +114,6 @@ pub fn init_core(pager: &Pager, rm: RunMode) -> std::result::Result<(), MinusErr
             drop(rm);
             return Ok(());
         }
-    }
-
-    {
-        let mut runmode = super::RUNMODE.lock();
-        assert!(runmode.is_uninitialized(), "Failed to set the RUNMODE. This is caused probably because another instance of minus is already running");
-        *runmode = rm;
-        drop(runmode);
     }
 
     // Setup terminal, adjust line wraps and get rows


### PR DESCRIPTION
Code setting RUNMODE was moved too far in 63328d02.

First, code checks if RUNMODE is static and only then it sets it to the selected mode. This way special cases when the stdout isn't a terminal or the output fits completely on the screen are not being hit.