### PR TITLE
fix rust-toolchain of flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,9 @@
           inherit system overlays;
         };
 
-        rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+          extensions = [ "rust-analyzer" ];
+        };
 
       in
       with pkgs;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.67.0"
-components = ["rust-src", "rust-analyzer", "rustfmt"]
+components = ["rust-src", "rustfmt"]


### PR DESCRIPTION
Alright, this time it should work. rust-analyzer is added in the flake itself so you will not install rust-analyzer if you don't use the dev-shell from the flake.