### PR TITLE
Change README

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,7 @@
 //! | Mouse scroll Up   | Scroll up by 5 lines                                                         |
 //! | Mouse scroll Down | Scroll down by 5 lines                                                       |
 //! | Ctrl+L            | Toggle line numbers if not forced enabled/disabled                           |
+//! | Ctrl+f            | Toggle [follow-mode]                                                         |
 //! | /                 | Start forward search                                                         |
 //! | ?                 | Start backward search                                                        |
 //! | Esc               | Cancel search input                                                          |
@@ -222,6 +223,7 @@
 //! [`tokio`]: https://docs.rs/tokio
 //! [`async-std`]: https://docs.rs/async-std
 //! [`Threads`]: std::thread
+//! [follow-mode]: struct.Pager.html#method.follow_output
 
 #[cfg(feature = "dynamic_output")]
 mod dynamic_pager;


### PR DESCRIPTION
So yeah, here's a first step for the README in my opinion: Reduce the amount of text by removing some redundant text.

The reason for this changes are, in my opinion, that users want to which benefits they are getting from this and most people look after crates like this hence they normally should know what a pager is.