### PR TITLE
feat: Command queue

### DIFF
--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -23,6 +23,9 @@ pub enum Command {
     AddExitCallback(Box<dyn FnMut() + Send + Sync + 'static>),
     ShowPrompt(bool),
     FollowOutput(bool),
+    FormatRedrawPrompt,
+    FormatRedrawDisplay,
+    UpdateUpperMark(usize),
     #[cfg(feature = "static_output")]
     SetRunNoOverflow(bool),
     #[cfg(feature = "search")]
@@ -39,6 +42,7 @@ impl PartialEq for Command {
             (Self::SetLineNumbers(d1), Self::SetLineNumbers(d2)) => d1 == d2,
             (Self::ShowPrompt(d1), Self::ShowPrompt(d2)) => d1 == d2,
             (Self::SetExitStrategy(d1), Self::SetExitStrategy(d2)) => d1 == d2,
+            (Self::UpdateUpperMark(um1), Self::UpdateUpperMark(um2)) => um1 == um2,
             #[cfg(feature = "static_output")]
             (Self::SetRunNoOverflow(d1), Self::SetRunNoOverflow(d2)) => d1 == d2,
             (Self::SetInputClassifier(_), Self::SetInputClassifier(_))
@@ -61,6 +65,9 @@ impl Debug for Command {
             Self::SetExitStrategy(es) => write!(f, "SetExitStrategy({es:?})"),
             Self::SetInputClassifier(_) => write!(f, "SetInputClassifier"),
             Self::ShowPrompt(show) => write!(f, "ShowPrompt({show:?})"),
+            Self::FormatRedrawPrompt => write!(f, "FormatRedrawPrompt"),
+            Self::FormatRedrawDisplay => write!(f, "FormatRedrawDisplay"),
+            Self::UpdateUpperMark(um) => write!(f, "UpdateUpperMark({um:?})"),
             #[cfg(feature = "search")]
             Self::IncrementalSearchCondition(_) => write!(f, "IncrementalSearchCondition"),
             Self::AddExitCallback(_) => write!(f, "AddExitCallback"),

--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -25,7 +25,6 @@ pub enum Command {
     FollowOutput(bool),
     FormatRedrawPrompt,
     FormatRedrawDisplay,
-    UpdateUpperMark(usize),
     #[cfg(feature = "static_output")]
     SetRunNoOverflow(bool),
     #[cfg(feature = "search")]
@@ -42,7 +41,6 @@ impl PartialEq for Command {
             (Self::SetLineNumbers(d1), Self::SetLineNumbers(d2)) => d1 == d2,
             (Self::ShowPrompt(d1), Self::ShowPrompt(d2)) => d1 == d2,
             (Self::SetExitStrategy(d1), Self::SetExitStrategy(d2)) => d1 == d2,
-            (Self::UpdateUpperMark(um1), Self::UpdateUpperMark(um2)) => um1 == um2,
             #[cfg(feature = "static_output")]
             (Self::SetRunNoOverflow(d1), Self::SetRunNoOverflow(d2)) => d1 == d2,
             (Self::SetInputClassifier(_), Self::SetInputClassifier(_))
@@ -67,7 +65,6 @@ impl Debug for Command {
             Self::ShowPrompt(show) => write!(f, "ShowPrompt({show:?})"),
             Self::FormatRedrawPrompt => write!(f, "FormatRedrawPrompt"),
             Self::FormatRedrawDisplay => write!(f, "FormatRedrawDisplay"),
-            Self::UpdateUpperMark(um) => write!(f, "UpdateUpperMark({um:?})"),
             #[cfg(feature = "search")]
             Self::IncrementalSearchCondition(_) => write!(f, "IncrementalSearchCondition"),
             Self::AddExitCallback(_) => write!(f, "AddExitCallback"),
@@ -88,13 +85,5 @@ impl Command {
     #[allow(dead_code)]
     pub(crate) const fn is_movement(&self) -> bool {
         matches!(self, Self::UserInput(InputEvent::UpdateUpperMark(_)))
-    }
-
-    #[cfg(feature = "dynamic_output")]
-    pub(crate) const fn required_immediate_screen_update(&self) -> bool {
-        matches!(
-            self,
-            Self::SetData(_) | Self::SetPrompt(_) | Self::SendMessage(_) | Self::ShowPrompt(_)
-        )
     }
 }

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -304,11 +304,19 @@ mod tests {
 
     // Tests for event emitting functions of Pager
     #[test]
+    #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
     fn set_data() {
         let mut ps = PagerState::new().unwrap();
         let ev = Command::SetData(TEST_STR.to_string());
         let mut out = Vec::new();
-        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        #[cfg(feature = "dynamic_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        }
+        #[cfg(feature = "static_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Static;
+        }
         let mut command_queue = CommandQueue::new_zero();
 
         handle_event(
@@ -369,12 +377,20 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
     fn set_prompt() {
         let mut ps = PagerState::new().unwrap();
         let ev = Command::SetPrompt(TEST_STR.to_string());
         let mut out = Vec::new();
         let mut command_queue = CommandQueue::new_zero();
-        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        #[cfg(feature = "dynamic_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        }
+        #[cfg(feature = "static_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Static;
+        }
 
         handle_event(
             ev,
@@ -390,9 +406,17 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
     fn send_message() {
         let mut ps = PagerState::new().unwrap();
-        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        #[cfg(feature = "dynamic_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
+        }
+        #[cfg(feature = "static_output")]
+        {
+            *crate::minus_core::RUNMODE.lock() = RunMode::Static;
+        }
         let ev = Command::SendMessage(TEST_STR.to_string());
         let mut out = Vec::new();
         let mut command_queue = CommandQueue::new_zero();

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -288,7 +288,7 @@ pub fn handle_event(
 mod tests {
     use super::super::commands::Command;
     use super::handle_event;
-    use crate::{minus_core::CommandQueue, ExitStrategy, PagerState};
+    use crate::{minus_core::CommandQueue, ExitStrategy, PagerState, RunMode};
     use std::sync::{atomic::AtomicBool, Arc};
     #[cfg(feature = "search")]
     use {
@@ -308,10 +308,21 @@ mod tests {
         let mut ps = PagerState::new().unwrap();
         let ev = Command::SetData(TEST_STR.to_string());
         let mut out = Vec::new();
+        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
         let mut command_queue = CommandQueue::new_zero();
 
         handle_event(
             ev,
+            &mut out,
+            &mut ps,
+            &mut command_queue,
+            &Arc::new(AtomicBool::new(false)),
+            #[cfg(feature = "search")]
+            &UIA,
+        )
+        .unwrap();
+        handle_event(
+            command_queue.pop_front().unwrap(),
             &mut out,
             &mut ps,
             &mut command_queue,
@@ -363,6 +374,7 @@ mod tests {
         let ev = Command::SetPrompt(TEST_STR.to_string());
         let mut out = Vec::new();
         let mut command_queue = CommandQueue::new_zero();
+        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
 
         handle_event(
             ev,
@@ -380,6 +392,7 @@ mod tests {
     #[test]
     fn send_message() {
         let mut ps = PagerState::new().unwrap();
+        *crate::minus_core::RUNMODE.lock() = RunMode::Dynamic;
         let ev = Command::SendMessage(TEST_STR.to_string());
         let mut out = Vec::new();
         let mut command_queue = CommandQueue::new_zero();

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -260,21 +260,17 @@ fn start_reactor(
                 Ok(command_queue.pop_front().unwrap())
             };
 
-            let mut p = ps.lock();
-
-            match next_command {
-                Ok(ev) => {
-                    handle_event(
-                        ev,
-                        &mut out_lock,
-                        &mut p,
-                        &mut command_queue,
-                        is_exited,
-                        #[cfg(feature = "search")]
-                        input_thread_running,
-                    )?;
-                }
-                Err(_) => {}
+            if let Ok(command) = next_command {
+                let mut p = ps.lock();
+                handle_event(
+                    command,
+                    &mut out_lock,
+                    &mut p,
+                    &mut command_queue,
+                    is_exited,
+                    #[cfg(feature = "search")]
+                    input_thread_running,
+                )?;
             }
         },
         #[cfg(feature = "static_output")]

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -243,7 +243,7 @@ fn start_reactor(
         }
     }
 
-    let run_mode = RUNMODE.lock().clone();
+    let run_mode = *RUNMODE.lock();
     match run_mode {
         #[cfg(feature = "dynamic_output")]
         RunMode::Dynamic => loop {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -45,9 +45,7 @@ impl CommandQueue {
     /// This function will panic if it is called in an environment where [RUNMODE] is
     /// uninitialized.
     pub fn push_back(&mut self, value: Command) {
-        if RUNMODE.lock().is_uninitialized() {
-            panic!();
-        }
+        assert!(!RUNMODE.lock().is_uninitialized(), "CommandQueue::push_back() caled when  RUNMODE is not set. This is most likely a bug. Please report the issue on minus's issue tracker on Github.");
         self.0.push_back(value);
     }
     /// Store `value` without checking [RUNMODE].

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,9 +1,42 @@
+use std::collections::VecDeque;
+
 pub mod commands;
 pub mod ev_handler;
 #[cfg(any(feature = "dynamic_output", feature = "static_output"))]
 pub mod init;
 pub mod utils;
 pub static RUNMODE: parking_lot::Mutex<RunMode> = parking_lot::const_mutex(RunMode::Uninitialized);
+
+use commands::Command;
+
+pub struct CommandQueue(VecDeque<Command>);
+
+impl CommandQueue {
+    pub fn new() -> Self {
+        Self(VecDeque::with_capacity(10))
+    }
+    pub fn new_zero() -> Self {
+        Self(VecDeque::with_capacity(0))
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn push_back_unchecked(&mut self, value: Command) {
+        self.0.push_back(value);
+    }
+    pub fn push_back(&mut self, value: Command) {
+        if RUNMODE.lock().is_uninitialized() {
+            panic!();
+        }
+        self.0.push_back(value);
+    }
+    pub fn pop_front(&mut self) -> Option<Command> {
+        self.0.pop_front()
+    }
+}
 
 /// Define the modes in which minus can run
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,9 +18,6 @@ impl CommandQueue {
     pub fn new_zero() -> Self {
         Self(VecDeque::with_capacity(0))
     }
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,25 +9,53 @@ pub static RUNMODE: parking_lot::Mutex<RunMode> = parking_lot::const_mutex(RunMo
 
 use commands::Command;
 
+/// A [VecDeque] to hold [Command]s to be executed after the current command has been executed
+///
+/// Many [Command]s in minus require additional commands to be executed once the current command's
+/// main objective has ben completed. For example the [SetLineNumbers](Command::SetLineNumbers)
+/// requires the text data to be reformatted and repainted on the screen. Hence it can push that
+/// command to this to be executed once it itself has completed executing.
+///
+/// This also takes into account [RUNMODE] before inserting data. See
+/// [push_back](CommandQueue::push_back) for more on this. The means that it will ensure that
+/// [RUNMODE] is not uninitialized before pushing any data into the queue.
+///
+/// This is a FIFO type hence the command that enters first gets executed first.
 pub struct CommandQueue(VecDeque<Command>);
 
 impl CommandQueue {
+    /// Create a new CommandQueue with default size of 10.
     pub fn new() -> Self {
         Self(VecDeque::with_capacity(10))
     }
+    /// Create a new CommandQueue with zero memory allocation.
+    ///
+    /// This is useful when we have to pass this type to [handle_event](ev_handler::handle_event)
+    /// but it is sure that this won't be used.
     pub fn new_zero() -> Self {
         Self(VecDeque::with_capacity(0))
     }
+    /// Returns true if the queue is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
-    pub fn push_back_unchecked(&mut self, value: Command) {
-        self.0.push_back(value);
-    }
+    /// Store `value` only if [RUNMODE] is not unintialized.
+    ///
+    /// # Panics
+    /// This function will panic if it is called in an environment where [RUNMODE] is
+    /// uninitialized.
     pub fn push_back(&mut self, value: Command) {
         if RUNMODE.lock().is_uninitialized() {
             panic!();
         }
+        self.0.push_back(value);
+    }
+    /// Store `value` without checking [RUNMODE].
+    ///
+    /// This is only meant to be used as an optimization over [push_back](CommandQueue::push_back)
+    /// when it is absolutely sure that [RUNMODE] isn't uninitialized. Hence calling this in an
+    /// enviroment where [RUNMODE] is uninitialized can lead to unexpect slowdowns.
+    pub fn push_back_unchecked(&mut self, value: Command) {
         self.0.push_back(value);
     }
     pub fn pop_front(&mut self) -> Option<Command> {

--- a/src/core/utils/display/mod.rs
+++ b/src/core/utils/display/mod.rs
@@ -117,6 +117,7 @@ pub fn draw_for_change(
 /// Write given text at the prompt site
 pub fn write_prompt(out: &mut impl Write, text: &str, rows: u16) -> Result<(), MinusError> {
     write!(out, "{mv}\r{prompt}", mv = MoveTo(0, rows), prompt = text)?;
+    out.flush()?;
     Ok(())
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,6 +9,7 @@ use crate::{
     minus_core::{
         self,
         utils::text::{self, AppendStyle},
+        CommandQueue,
     },
     screen::Screen,
     ExitStrategy, LineNumbers,
@@ -236,11 +237,13 @@ impl PagerState {
         mut out: &mut Stdout,
     ) -> Result<Self, MinusError> {
         let mut ps = Self::new()?;
+        let mut command_queue = CommandQueue::new_zero();
         rx.try_iter().try_for_each(|ev| -> Result<(), MinusError> {
             handle_event(
                 ev,
                 &mut out,
                 &mut ps,
+                &mut command_queue,
                 &Arc::new(AtomicBool::new(false)),
                 #[cfg(feature = "search")]
                 &Arc::new((Mutex::new(true), Condvar::new())),


### PR DESCRIPTION
Many `Commands` is minus require additional operations to be done after their main objective have been completed. One example of this would be something like the `Search` command which after executing successfully also requires a update of the prompt to show the search match count. Currently all such commands directly use the functions handling these operations which makes the code look more confusing as well as introduces code duplication.

To solve this issue, a new type called `CommandQueue` is being introduced so that each`Ccommand` can issue other `Command`s to be executed once its main objective is finished executing. 

Although the implementation of this new type is mostly complete, we need to port all the `Command`s that require such cases to use this new type