### PR TITLE
Investigate screen flickering on WSL/Windows Terminal

### DIFF
--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -267,6 +267,7 @@ fn start_reactor(
                     let ev = Command::UserInput(ev);
                     let is_exit_event = ev.is_exit_event();
                     let is_movement = ev.is_movement();
+                    let is_ignore = inp == InputEvent::Ignore;
                     handle_event(
                         ev,
                         &mut out_lock,
@@ -284,7 +285,7 @@ fn start_reactor(
                             p.rows.try_into().unwrap(),
                         )?;
                     }
-                    if !is_exit_event && !is_movement {
+                    if !is_ignore && !is_exit_event && !is_movement {
                         draw_full(&mut out_lock, &mut p)?;
                     }
                 }
@@ -326,8 +327,6 @@ fn start_reactor(
                 }
 
                 if let Ok(Command::UserInput(inp)) = rx.recv() {
-                    // dbg!(inp);
-                    // std::thread::sleep(std::time::Duration::from_millis(100));
                     let mut p = ps.lock();
                     let is_exit_event = Command::UserInput(inp).is_exit_event();
                     let is_movement = Command::UserInput(inp).is_movement();

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -326,11 +326,12 @@ fn start_reactor(
                 }
 
                 if let Ok(Command::UserInput(inp)) = rx.recv() {
-                    dbg!(inp);
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    // dbg!(inp);
+                    // std::thread::sleep(std::time::Duration::from_millis(100));
                     let mut p = ps.lock();
                     let is_exit_event = Command::UserInput(inp).is_exit_event();
                     let is_movement = Command::UserInput(inp).is_movement();
+                    let is_ignore = inp == InputEvent::Ignore;
                     handle_event(
                         Command::UserInput(inp),
                         &mut out_lock,
@@ -339,7 +340,7 @@ fn start_reactor(
                         #[cfg(feature = "search")]
                         input_thread_running,
                     )?;
-                    if !is_exit_event && !is_movement {
+                    if !is_ignore && !is_exit_event && !is_movement {
                         draw_full(&mut out_lock, &mut p)?;
                     }
                 }

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -326,6 +326,8 @@ fn start_reactor(
                 }
 
                 if let Ok(Command::UserInput(inp)) = rx.recv() {
+                    dbg!(inp);
+                    std::thread::sleep(std::time::Duration::from_millis(100));
                     let mut p = ps.lock();
                     let is_exit_event = Command::UserInput(inp).is_exit_event();
                     let is_movement = Command::UserInput(inp).is_movement();

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -267,7 +267,7 @@ fn start_reactor(
                     let ev = Command::UserInput(ev);
                     let is_exit_event = ev.is_exit_event();
                     let is_movement = ev.is_movement();
-                    let is_ignore = inp == InputEvent::Ignore;
+                    let is_ignore = ev == Command::UserInput(InputEvent::Ignore);
                     handle_event(
                         ev,
                         &mut out_lock,


### PR DESCRIPTION
@EiEddie can you test your code from this branch?. It will print out the events on the screen before handling them on the screen. This will help us investigate all the events that the event reader is reading.