### PR TITLE
Add a way to persist the alternate screen on exit

### DIFF
--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -34,6 +34,7 @@ pub enum Command {
 
     // Configuration options
     SetExitStrategy(ExitStrategy),
+    PersistAlternate(bool),
     SetInputClassifier(Box<dyn InputClassifier + Send + Sync + 'static>),
     AddExitCallback(Box<dyn FnMut() + Send + Sync + 'static>),
     #[cfg(feature = "static_output")]
@@ -70,6 +71,7 @@ impl PartialEq for Command {
 impl Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::PersistAlternate(persist) => write!(f, "PersistAlternate({persist})"),
             Self::SetData(text) => write!(f, "SetData({text:?})"),
             Self::AppendData(text) => write!(f, "AppendData({text:?})"),
             Self::SetPrompt(text) => write!(f, "SetPrompt({text:?})"),

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -133,6 +133,7 @@ pub fn init_core(pager: &Pager, rm: RunMode) -> std::result::Result<(), MinusErr
                 stdout(),
                 &crate::ExitStrategy::PagerQuit,
                 true,
+                false,
             ));
             panic_hook(pinfo);
         }));
@@ -169,7 +170,7 @@ pub fn init_core(pager: &Pager, rm: RunMode) -> std::result::Result<(), MinusErr
                 let mut rm = RUNMODE.lock();
                 *rm = RunMode::Uninitialized;
                 drop(rm);
-                term::cleanup(out.as_ref(), &crate::ExitStrategy::PagerQuit, true)?;
+                term::cleanup(out.as_ref(), &crate::ExitStrategy::PagerQuit, true, false)?;
             }
             res
         });
@@ -188,7 +189,12 @@ pub fn init_core(pager: &Pager, rm: RunMode) -> std::result::Result<(), MinusErr
                 let mut rm = RUNMODE.lock();
                 *rm = RunMode::Uninitialized;
                 drop(rm);
-                term::cleanup(out_copy.as_ref(), &crate::ExitStrategy::PagerQuit, true)?;
+                term::cleanup(
+                    out_copy.as_ref(),
+                    &crate::ExitStrategy::PagerQuit,
+                    true,
+                    false,
+                )?;
             }
             res
         });

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -186,6 +186,15 @@ impl Pager {
         Ok(self.tx.send(Command::SetExitStrategy(es))?)
     }
 
+    /// Set if minus persists the alternate screen buffer on exit.
+    ///
+    /// This controls how the pager will behave with regards to clearing the screen when
+    /// the user presses `q` or `Ctrl+C'. If it is set, instead of clearing the screen
+    /// when exited, it will continue to show.
+    pub fn persist_alternate_screen(&self, b: bool) -> Result<(), MinusError> {
+        Ok(self.tx.send(Command::PersistAlternate(b))?)
+    }
+
     /// Set whether to display pager if there's less data than
     /// available screen height
     ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -143,6 +143,9 @@ pub struct PagerState {
     /// The behaviour to do when user quits the program using `q` or `Ctrl+C`
     /// See [`ExitStrategy`] for available options
     pub(crate) exit_strategy: ExitStrategy,
+    /// The behaviour to do when user quits the program using `q` or `Ctrl+C`
+    /// See [persist_alternate_screen](crate::pager::Pager::persist_alternate_screen) for more info.
+    pub(crate) persist_alternate: bool,
     /// The prompt that should be displayed to the user, formatted with the
     /// current search index and number of matches (if the search feature is enabled),
     /// and the current numbers inputted to scroll
@@ -194,6 +197,7 @@ impl PagerState {
             prompt,
             running: &minus_core::RUNMODE,
             exit_strategy: ExitStrategy::ProcessQuit,
+            persist_alternate: false,
             input_classifier: Box::<HashedEventRegister<RandomState>>::default(),
             exit_callbacks: Vec::with_capacity(5),
             message: None,


### PR DESCRIPTION
I was looking for a way to get similar behavior to `-X` with `less`, where the buffer stays on screen after exit.