### PR TITLE
Implement some small fixes and find end position of match

### DIFF
--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -72,13 +72,13 @@ impl PartialEq for Command {
 impl Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::SetData(text) => write!(f, "SetData({:?})", text),
-            Self::AppendData(text) => write!(f, "AppendData({:?})", text),
-            Self::SetPrompt(text) => write!(f, "SetPrompt({:?})", text),
-            Self::SendMessage(text) => write!(f, "SendMessage({:?})", text),
-            Self::SetLineNumbers(ln) => write!(f, "SetLineNumbers({:?})", ln),
-            Self::LineWrapping(lw) => write!(f, "LineWrapping({:?})", lw),
-            Self::SetExitStrategy(es) => write!(f, "SetExitStrategy({:?})", es),
+            Self::SetData(text) => write!(f, "SetData({text:?})"),
+            Self::AppendData(text) => write!(f, "AppendData({text:?})"),
+            Self::SetPrompt(text) => write!(f, "SetPrompt({text:?})"),
+            Self::SendMessage(text) => write!(f, "SendMessage({text:?})"),
+            Self::SetLineNumbers(ln) => write!(f, "SetLineNumbers({ln:?})"),
+            Self::LineWrapping(lw) => write!(f, "LineWrapping({lw:?})"),
+            Self::SetExitStrategy(es) => write!(f, "SetExitStrategy({es:?})"),
             Self::SetInputClassifier(_) => write!(f, "SetInputClassifier"),
             Self::ShowPrompt(show) => write!(f, "ShowPrompt({show:?})"),
             Self::FormatRedrawPrompt => write!(f, "FormatRedrawPrompt"),

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -12,6 +12,7 @@ use super::CommandQueue;
 use super::{commands::Command, utils::term};
 #[cfg(feature = "search")]
 use crate::search;
+use crate::search::SearchMatch;
 use crate::{error::MinusError, input::InputEvent, PagerState};
 
 /// Respond based on the type of command
@@ -138,8 +139,12 @@ pub fn handle_event(
             if p.search_state.search_term.is_some() =>
         {
             // Move to next search match after the current upper_mark
-            let position_of_next_match =
-                search::next_nth_match(&p.search_state.search_idx, p.upper_mark, 1);
+            let position_of_next_match = search::next_nth_match(
+                &p.search_state.search_idx,
+                p.upper_mark,
+                p.left_mark + p.cols,
+                1,
+            );
             if let Some(pnm) = position_of_next_match {
                 p.search_state.search_mark = pnm;
                 let upper_mark = p
@@ -148,7 +153,7 @@ pub fn handle_event(
                     .iter()
                     .nth(p.search_state.search_mark)
                     .unwrap()
-                    .0;
+                    .row;
                 command_queue.push_back_unchecked(Command::UserInput(InputEvent::UpdateUpperMark(
                     upper_mark,
                 )));
@@ -165,7 +170,7 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceding index
             p.search_state.search_mark = p.search_state.search_mark.saturating_sub(1);
-            if let Some((y, _)) = p
+            if let Some(SearchMatch { row: y, .. }) = p
                 .search_state
                 .search_idx
                 .iter()
@@ -186,8 +191,12 @@ pub fn handle_event(
             if p.search_state.search_term.is_some() =>
         {
             // Move to next nth search match after the current upper_mark
-            let position_of_next_match =
-                search::next_nth_match(&p.search_state.search_idx, p.upper_mark, n);
+            let position_of_next_match = search::next_nth_match(
+                &p.search_state.search_idx,
+                p.upper_mark,
+                p.left_mark + p.cols,
+                n,
+            );
             if let Some(pnm) = position_of_next_match {
                 p.search_state.search_mark = pnm;
                 let upper_mark = p
@@ -196,7 +205,7 @@ pub fn handle_event(
                     .iter()
                     .nth(p.search_state.search_mark)
                     .unwrap()
-                    .0;
+                    .row;
 
                 // Ensure there is enough text available after location corresponding to
                 // position_of_next_match so that we can display a pagefull of data. If not,
@@ -212,7 +221,7 @@ pub fn handle_event(
                         .iter()
                         .nth(p.search_state.search_mark)
                         .unwrap()
-                        .0;
+                        .row;
                 }
                 command_queue.push_back_unchecked(Command::UserInput(InputEvent::UpdateUpperMark(
                     upper_mark,
@@ -230,7 +239,7 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceding index
             p.search_state.search_mark = p.search_state.search_mark.saturating_sub(n);
-            if let Some((y, _)) = p
+            if let Some(SearchMatch { row: y, .. }) = p
                 .search_state
                 .search_idx
                 .iter()

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -142,12 +142,13 @@ pub fn handle_event(
                 search::next_nth_match(&p.search_state.search_idx, p.upper_mark, 1);
             if let Some(pnm) = position_of_next_match {
                 p.search_state.search_mark = pnm;
-                let upper_mark = *p
+                let upper_mark = p
                     .search_state
                     .search_idx
                     .iter()
                     .nth(p.search_state.search_mark)
-                    .unwrap();
+                    .unwrap()
+                    .0;
                 command_queue.push_back_unchecked(Command::UserInput(InputEvent::UpdateUpperMark(
                     upper_mark,
                 )));
@@ -164,7 +165,7 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceding index
             p.search_state.search_mark = p.search_state.search_mark.saturating_sub(1);
-            if let Some(y) = p
+            if let Some((y, _)) = p
                 .search_state
                 .search_idx
                 .iter()
@@ -189,12 +190,13 @@ pub fn handle_event(
                 search::next_nth_match(&p.search_state.search_idx, p.upper_mark, n);
             if let Some(pnm) = position_of_next_match {
                 p.search_state.search_mark = pnm;
-                let upper_mark = *p
+                let upper_mark = p
                     .search_state
                     .search_idx
                     .iter()
                     .nth(p.search_state.search_mark)
-                    .unwrap();
+                    .unwrap()
+                    .0;
 
                 // Ensure there is enough text available after location corresponding to
                 // position_of_next_match so that we can display a pagefull of data. If not,
@@ -204,12 +206,13 @@ pub fn handle_event(
                     > p.screen.formatted_lines_count().saturating_add(1)
                 {
                     p.search_state.search_mark = p.search_state.search_mark.saturating_sub(1);
-                    p.upper_mark = *p
+                    p.upper_mark = p
                         .search_state
                         .search_idx
                         .iter()
                         .nth(p.search_state.search_mark)
-                        .unwrap();
+                        .unwrap()
+                        .0;
                 }
                 command_queue.push_back_unchecked(Command::UserInput(InputEvent::UpdateUpperMark(
                     upper_mark,
@@ -227,7 +230,7 @@ pub fn handle_event(
             }
             // Decrement the s_mark and get the preceding index
             p.search_state.search_mark = p.search_state.search_mark.saturating_sub(n);
-            if let Some(y) = p
+            if let Some((y, _)) = p
                 .search_state
                 .search_idx
                 .iter()

--- a/src/input/hashed_event_register.rs
+++ b/src/input/hashed_event_register.rs
@@ -231,20 +231,20 @@ where
     /// Prefer using this over [add_key_events](HashedEventRegister::add_key_events).
     ///
     /// # Example
-    /// ```
+    /// ```should_panic
     /// use minus::input::{InputEvent, HashedEventRegister, crossterm_event};
     ///
     /// let mut input_register = HashedEventRegister::default();
     ///
-    /// input_register.add_key_events(&["down"], |_, ps| {
+    /// input_register.add_key_events_checked(&["down"], |_, ps| {
     ///     InputEvent::UpdateUpperMark(ps.upper_mark.saturating_sub(1))
-    /// });
+    /// }, false);
     /// ```
     pub fn add_key_events_checked(
         &mut self,
         desc: &[&str],
-        remap: bool,
         cb: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+        remap: bool,
     ) {
         let v = Arc::new(cb);
         for k in desc {
@@ -315,26 +315,27 @@ where
     ///
     /// Prefer using this over [add_mouse_events](HashedEventRegister::add_mouse_events).
     /// # Example
-    /// ```
+    /// ```should_panic
     /// use minus::input::{InputEvent, HashedEventRegister};
     ///
     /// let mut input_register = HashedEventRegister::default();
     ///
-    /// input_register.add_mouse_events(&["scroll:down"], |_, ps| {
+    /// input_register.add_mouse_events_checked(&["scroll:down"], |_, ps| {
     ///     InputEvent::UpdateUpperMark(ps.upper_mark.saturating_sub(5))
-    /// });
+    /// }, false);
     /// ```
     pub fn add_mouse_events_checked(
         &mut self,
         desc: &[&str],
         cb: impl Fn(Event, &PagerState) -> InputEvent + Send + Sync + 'static,
+        remap: bool,
     ) {
         let v = Arc::new(cb);
         for k in desc {
-            self.0.insert(
-                Event::Mouse(super::definitions::mousedefs::parse_mouse_event(k)).into(),
-                v.clone(),
-            );
+            let def: EventWrapper =
+                Event::Mouse(super::definitions::mousedefs::parse_mouse_event(k)).into();
+            assert!(self.0.contains_key(&def) && remap, "");
+            self.0.insert(def, v.clone());
         }
     }
 

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -3,6 +3,7 @@
 //! This module is still a work is progress and is subject to change.
 use crate::{
     minus_core::{self, utils::LinesRowMap},
+    search::SearchMatch,
     LineNumbers,
 };
 #[cfg(feature = "search")]
@@ -471,7 +472,11 @@ where
         fr.append_search_idx = fr
             .append_search_idx
             .iter()
-            .map(|i| (opts.formatted_lines_count + i.0, i.1))
+            .map(|i| SearchMatch {
+                row: i.row + formatted_row_count,
+                col: i.col,
+                shifted_col: i.shifted_col,
+            })
             .collect();
     }
 

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -546,13 +546,11 @@ pub(crate) fn formatted_line<'a>(
 
     // highlight the lines with matching search terms
     // If a match is found, add this line's index to PagerState::search_idx
-    #[cfg_attr(not(feature = "search"), allow(unused_mut))]
-    #[cfg_attr(not(feature = "search"), allow(unused_variables))]
+    #[cfg_attr(not(feature = "search"), allow(unused_mut, unused_variables))]
     let mut handle_search = |row: &mut Cow<'a, str>, wrap_idx: usize| {
         #[cfg(feature = "search")]
         if let Some(st) = search_term.as_ref() {
-            let (highlighted_row, is_match) = search::highlight_line_matches(row, st, false);
-            if is_match {
+            if let Some(highlighted_row) = search::highlight_line_matches(row, st, false) {
                 *row.to_mut() = highlighted_row;
                 search_idx.insert(formatted_idx + wrap_idx);
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -678,14 +678,17 @@ pub(crate) fn highlight_line_matches(
     // into the stripped string at the point where it is being checked.
     let mut inserted_escs_len = 0;
     for esc in &escapes {
-        let match_count: usize = matches.iter()
+        let match_count: usize = matches
+            .iter()
             .take_while(|(s, _)| *s <= esc.0)
-            .map(|(_, e)| if *e <= esc.0 {
-                // if the end of the match is at the same point as the escape, the NORMAL should be
-                // inserted before the escape so that the escape isn't immediately negated
-                2
-            } else {
-                1
+            .map(|(_, e)| {
+                if *e <= esc.0 {
+                    // if the end of the match is at the same point as the escape, the NORMAL should be
+                    // inserted before the escape so that the escape isn't immediately negated
+                    2
+                } else {
+                    1
+                }
             })
             .sum();
         // Find how many invert|normal markers appear before this escape
@@ -728,7 +731,8 @@ pub(crate) fn highlight_line_matches(
 
         // then we need to find all of the escapes which would be placed before it in the final
         // string
-        let escapes: usize = escapes.iter()
+        let escapes: usize = escapes
+            .iter()
             // we take them while their start position in the stripped string is before the end
             // position of this match in the final string. We use `<` instead of `<=` b/c we insert
             // the escapes back into the inverted string after the NORMAL
@@ -1150,7 +1154,8 @@ eros.",
             #[test]
             fn single_match_no_esc() {
                 let res =
-                    highlight_line_matches("this is a test", &Regex::new(" a ").unwrap(), false).unwrap();
+                    highlight_line_matches("this is a test", &Regex::new(" a ").unwrap(), false)
+                        .unwrap();
                 assert_eq!(res, format!("this is{} a {}test", *INVERT, *NORMAL));
             }
 
@@ -1160,7 +1165,8 @@ eros.",
                     "test another test",
                     &Regex::new("test").unwrap(),
                     false,
-                ).unwrap();
+                )
+                .unwrap();
                 assert_eq!(
                     res,
                     format!("{i}test{n} another {i}test{n}", i = *INVERT, n = *NORMAL)
@@ -1175,7 +1181,8 @@ eros.",
                     &format!("{ESC}color{NONE} and test"),
                     &Regex::new("test").unwrap(),
                     false,
-                ).unwrap();
+                )
+                .unwrap();
                 assert_eq!(
                     res,
                     format!("{}color{} and {}test{}", ESC, NONE, *INVERT, *NORMAL)
@@ -1185,7 +1192,8 @@ eros.",
             #[test]
             fn esc_pair_end_in_match() {
                 let orig = format!("this {ESC}is a te{NONE}st");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
                 assert_eq!(
                     res,
                     format!("this {}is a {}test{}{}", ESC, *INVERT, *NORMAL, NONE)
@@ -1195,7 +1203,8 @@ eros.",
             #[test]
             fn esc_pair_start_in_match() {
                 let orig = format!("this is a te{ESC}st again{NONE}");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
                 assert_eq!(
                     res,
                     format!("this is a {}test{}{ESC} again{}", *INVERT, *NORMAL, NONE)
@@ -1205,7 +1214,8 @@ eros.",
             #[test]
             fn esc_pair_around_match() {
                 let orig = format!("this is {ESC}a test again{NONE}");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
                 assert_eq!(
                     res,
                     format!("this is {}a {}test{} again{}", ESC, *INVERT, *NORMAL, NONE)
@@ -1215,7 +1225,8 @@ eros.",
             #[test]
             fn esc_pair_within_match() {
                 let orig = format!("this is a t{ESC}es{NONE}t again");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
                 assert_eq!(
                     res,
                     format!("this is a {}test{}{ESC}{NONE} again", *INVERT, *NORMAL)
@@ -1225,7 +1236,8 @@ eros.",
             #[test]
             fn multi_escape_match() {
                 let orig = format!("this {ESC}is a te{NONE}st again {ESC}yeah{NONE} test",);
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), false).unwrap();
                 assert_eq!(
                     res,
                     format!(
@@ -1246,7 +1258,8 @@ eros.",
                     "{ESC}test{NONE} this {ESC}is a te{NONE}st again {ESC}yeah{NONE} test",
                 );
 
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!(
@@ -1266,7 +1279,8 @@ eros.",
                     &format!("{ESC}color{NONE} and test"),
                     &Regex::new("test").unwrap(),
                     true,
-                ).unwrap();
+                )
+                .unwrap();
                 assert_eq!(
                     res,
                     format!("{}color{} and {}test{}", ESC, NONE, *INVERT, *NORMAL)
@@ -1276,7 +1290,8 @@ eros.",
             #[test]
             fn esc_pair_end_in_match() {
                 let orig = format!("this {ESC}is a te{NONE}st");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!("this {ESC}is a {}te{NONE}st{}", *INVERT, *NORMAL)
@@ -1286,7 +1301,8 @@ eros.",
             #[test]
             fn esc_pair_start_in_match() {
                 let orig = format!("this is a te{ESC}st again{NONE}");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!("this is a {}te{ESC}st{} again{NONE}", *INVERT, *NORMAL)
@@ -1296,7 +1312,8 @@ eros.",
             #[test]
             fn esc_pair_around_match() {
                 let orig = format!("this is {ESC}a test again{NONE}");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!("this is {ESC}a {}test{} again{NONE}", *INVERT, *NORMAL)
@@ -1306,7 +1323,8 @@ eros.",
             #[test]
             fn esc_pair_within_match() {
                 let orig = format!("this is a t{ESC}es{NONE}t again");
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!("this is a {}t{ESC}es{NONE}t{} again", *INVERT, *NORMAL)
@@ -1316,7 +1334,8 @@ eros.",
             #[test]
             fn multi_escape_match() {
                 let orig = format!("this {ESC}is a te{NONE}st again {ESC}yeah{NONE} test",);
-                let res = highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
+                let res =
+                    highlight_line_matches(&orig, &Regex::new("test").unwrap(), true).unwrap();
                 assert_eq!(
                     res,
                     format!(

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 //! Contains types that hold run-time information of the pager.
 
 #[cfg(feature = "search")]
-use crate::search::{SearchMode, SearchOpts};
+use crate::search::{SearchIndex, SearchMode, SearchOpts};
 
 use crate::{
     error::{MinusError, TermError},
@@ -44,7 +44,7 @@ pub struct SearchState {
     pub(crate) search_term: Option<regex::Regex>,
     /// Lines where searches have a match
     /// In order to avoid duplicate entries of lines, we keep it in a [`BTreeSet`]
-    pub(crate) search_idx: BTreeSet<usize>,
+    pub(crate) search_idx: SearchIndex,
     /// Index of search item currently in focus
     /// It should be 0 even when no search is in action
     pub(crate) search_mark: usize,


### PR DESCRIPTION
@arijit79 here's the PR to get the final end position of a match within a string

This PR also fixes a few other things that clippy was complaining about, and switches a `(String, bool)` to `Option<String>` to avoid an allocation