### PR TITLE
Fix order of mode restoration

### DIFF
--- a/src/core/utils/term.rs
+++ b/src/core/utils/term.rs
@@ -64,9 +64,9 @@ pub fn cleanup(
     if cleanup_screen {
         // Reverse order of setup.
         execute!(out, cursor::Show).map_err(|e| CleanupError::ShowCursor(e.into()))?;
-        terminal::disable_raw_mode().map_err(|e| CleanupError::DisableRawMode(e.into()))?;
         execute!(out, event::DisableMouseCapture)
             .map_err(|e| CleanupError::DisableMouseCapture(e.into()))?;
+        terminal::disable_raw_mode().map_err(|e| CleanupError::DisableRawMode(e.into()))?;
         execute!(out, terminal::LeaveAlternateScreen)
             .map_err(|e| CleanupError::LeaveAlternateScreen(e.into()))?;
     }


### PR DESCRIPTION
While using [Jujutsu](https://github.com/martinvonz/jj) on Windows 10/11 in PowerShell, I discovered a bug that's very easy to fix. Whenever I enter the pager (for example with `jj log`) for the second time in a row, it fails to properly repaint. That's because the order of operations in `term::cleanup` is not exactly the inverse of `term::setup`. The problem is that the `EnableMouseCapture` command in crossterm stores the current mode and `DisableMouseCapture` restores it, so in effect it used to restore raw mode (which was enabled before enabling mouse capture) during cleanup after having disabled it.

I only observed this behavior in PowerShell so far, not `cmd.exe`. Maybe only PowerShell respects these accidentally mixed up mode settings between invocations while `cmd.exe` restores the original mode somehow.