### PR TITLE
Add option to disable alternate screen buffer (RFC)

### DIFF
--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -37,6 +37,7 @@ pub enum Command {
     SetExitStrategy(ExitStrategy),
     SetInputClassifier(Box<dyn InputClassifier + Send + Sync + 'static>),
     AddExitCallback(Box<dyn FnMut() + Send + Sync + 'static>),
+    SetAlternateScreen(bool),
     #[cfg(feature = "static_output")]
     SetRunNoOverflow(bool),
     #[cfg(feature = "search")]
@@ -58,6 +59,7 @@ impl PartialEq for Command {
             (Self::SetLineNumbers(d1), Self::SetLineNumbers(d2)) => d1 == d2,
             (Self::ShowPrompt(d1), Self::ShowPrompt(d2)) => d1 == d2,
             (Self::SetExitStrategy(d1), Self::SetExitStrategy(d2)) => d1 == d2,
+            (Self::SetAlternateScreen(d1), Self::SetAlternateScreen(d2)) => d1 == d2,
             #[cfg(feature = "static_output")]
             (Self::SetRunNoOverflow(d1), Self::SetRunNoOverflow(d2)) => d1 == d2,
             (Self::SetInputClassifier(_), Self::SetInputClassifier(_))
@@ -90,6 +92,7 @@ impl Debug for Command {
             Self::SetRunNoOverflow(val) => write!(f, "SetRunNoOverflow({val:?})"),
             Self::UserInput(input) => write!(f, "UserInput({input:?})"),
             Self::FollowOutput(follow_output) => write!(f, "FollowOutput({follow_output:?})"),
+            Self::SetAlternateScreen(val) => write!(f, "SetAlternateScreen({val:?})"),
         }
     }
 }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -373,6 +373,26 @@ impl Pager {
         self.tx.send(Command::FollowOutput(follow_output))?;
         Ok(())
     }
+
+    /// Set whether to use the alternate screen buffer
+    ///
+    /// When set to `true` (the default), minus will use the terminal's alternate screen
+    /// buffer. This means that when the pager exits, the original terminal content
+    /// will be restored.
+    ///
+    /// When set to `false`, minus will display content directly in the main screen
+    /// buffer. The paged content will remain visible after the pager exits, similar
+    /// to how `cat` works.
+    ///
+    /// This setting must be configured before starting the pager. Changing it
+    /// while the pager is running has no effect.
+    ///
+    /// # Errors
+    /// This function will return a [`Err(MinusError::Communication)`](MinusError::Communication) if the data
+    /// could not be sent to the receiver
+    pub fn set_alternate_screen(&self, value: bool) -> Result<(), MinusError> {
+        Ok(self.tx.send(Command::SetAlternateScreen(value))?)
+    }
 }
 
 impl Default for Pager {

--- a/src/state.rs
+++ b/src/state.rs
@@ -153,6 +153,8 @@ pub struct PagerState {
     /// Value for follow mode.
     /// See [follow_output](crate::pager::Pager::follow_output) for more info on follow mode.
     pub(crate) follow_output: bool,
+    /// Whether to use the alternate screen buffer
+    pub(crate) use_alternate_screen: bool,
 }
 
 impl PagerState {
@@ -204,6 +206,7 @@ impl PagerState {
             prefix_num: String::new(),
             lines_to_row_map: LinesRowMap::new(),
             follow_output: false,
+            use_alternate_screen: true,
         };
 
         state.format_prompt();


### PR DESCRIPTION
Hi there, and thanks for making this wonderful crate!

It has been [powering](https://github.com/gitbutlerapp/gitbutler/blob/master/crates/but/src/utils/output_channel.rs#L325) the [GitButler CLI](https://github.com/gitbutlerapp/gitbutler) for a while and it worked flawlessly.

Just recently the desire to have a screen-less version came up and… I proto-vibed it. This PR is the result, but not to shove it onto you, but to have it as a basis for discussion and see if such a thing would ever have a chance to be merged.

Besides that, this implementation thus far seems to do the trick, and I wonder what you think about all that.

Thanks and cheers 🙏

PS: below the fold is all the information from the commit.

----

Add `Pager::set_alternate_screen(bool)` to control whether minus uses the terminal's alternate screen buffer. When set to false, paged content remains visible after the pager exits (like `cat`), instead of being cleared (like `less`).

This is useful for applications that want users to be able to see and copy the output after quitting the pager.

How does this implementation differ from less -X?

The key difference is:

less -X (termcap init/deinit):
- The -X flag tells less to not send the termcap initialization (ti) and deinitialization (te) strings
- This approach only suppresses the terminal initialization sequences, but less still operates normally internally
- The screen clearing behavior depends on terminal-specific escape codes

This implementation (alternate screen buffer):
- Directly controls whether to use the terminal's alternate screen buffer (EnterAlternateScreen/LeaveAlternateScreen)
- When use_alternate_screen is false:
- The pager writes directly to the main screen buffer
- Content remains visible after exit because we never switched to an alternate buffer in the first place
- Raw mode and mouse capture are still enabled/disabled properly
- When true (default): Works like traditional pagers - switches to alternate screen, then restores on exit

The practical effect is similar (content remains visible after exit), but this implementation is more explicit and portable because it uses crossterm's abstraction over the alternate
screen buffer rather than relying on terminal-specific termcap strings. The alternate screen buffer is a well-defined terminal feature (DECSET 1049/1047) that most modern terminal emulators support consistently.