### PR TITLE
Add bindings for Home, End and N

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -297,7 +297,7 @@ where
         let half_screen = ps.rows / 2;
         InputEvent::UpdateUpperMark(ps.upper_mark.saturating_add(half_screen))
     });
-    map.add_key_events(&["g"], |_, _| InputEvent::UpdateUpperMark(0));
+    map.add_key_events(&["g", "home"], |_, _| InputEvent::UpdateUpperMark(0));
 
     map.add_key_events(&["s-g", "G"], |_, ps| {
         let mut position = ps
@@ -328,6 +328,7 @@ where
     map.add_key_events(&["c-l"], |_, ps| {
         InputEvent::UpdateLineNumber(!ps.line_numbers)
     });
+    map.add_key_events(&["end"], |_, _| InputEvent::UpdateUpperMark(usize::MAX - 1));
     #[cfg(feature = "search")]
     {
         map.add_key_events(&["/"], |_, _| InputEvent::Search(SearchMode::Forward));
@@ -343,7 +344,7 @@ where
                 InputEvent::Ignore
             }
         });
-        map.add_key_events(&["p"], |_, ps| {
+        map.add_key_events(&["p", "s-n"], |_, ps| {
             let position = ps.prefix_num.parse::<usize>().unwrap_or(1);
 
             if ps.search_state.search_mode == SearchMode::Forward {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,8 @@
 //! | ?                   | Start backward search                                                        |
 //! | Esc                 | Cancel search input                                                          |
 //! | n                   | Go to the next search match                                                  |
-//! | p                   | Go to the next previous match                                                |
+//! | N                   | Go to the next previous match                                                |
+//! | p                   | Go to the next previous match (alternate keybinding)                            |
 //!
 //! End-applications are free to change these bindings to better suit their needs. See docs for
 //! [Pager::set_input_classifier] function and [input] module.


### PR DESCRIPTION
As requested in #150, minus lacked key bindings for the Home and End keys. This PR sets these keys to move the screen to the top and bottom of the screen, respectively.

Additionally, as pointed out, this PR also sets the `Shift`+`N` key binding to go to the previous search (similar to less). This does not replace the `p` key binding but rather works alongside it. These changes will be part of the upcoming minor release, and I don't want to make major changes to the default bindings in a minor release.

I am not sure what I should eventually be bound to the `p` key. I am looking forward to the community feedback on this.

cc: @academician