### PR TITLE
Improve Formatting API and Performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "^2"
 regex = { version = "^1", optional = true }
 crossbeam-channel = "^0.5"
 parking_lot = "0.12.1"
+rustyline = { version = "18.0.0", default-features = false, features = ["custom-bindings"] }
 
 [features]
 search = [ "regex" ]

--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -40,7 +40,7 @@ pub enum Command {
     #[cfg(feature = "static_output")]
     SetRunNoOverflow(bool),
     #[cfg(feature = "search")]
-    IncrementalSearchCondition(Box<dyn Fn(&SearchOpts) -> bool + Send + Sync + 'static>),
+    IncrementalSearchCondition(Box<dyn Fn(&SearchOpts, &str) -> bool + Send + Sync + 'static>),
 
     // Internal commands
     FormatRedrawPrompt,

--- a/src/core/ev_handler.rs
+++ b/src/core/ev_handler.rs
@@ -111,9 +111,9 @@ pub fn handle_event(
             if let Some(incremental_search_result) = search_result.incremental_search_result {
                 p.search_state.search_term = search_result.compiled_regex;
                 p.upper_mark = incremental_search_result.upper_mark;
-                p.search_state.search_mark = incremental_search_result.search_mark;
+                p.search_state.search_mark = 0;
                 p.search_state.search_idx = incremental_search_result.search_idx;
-                p.screen.formatted_lines = incremental_search_result.formatted_lines;
+                command_queue.push_back_unchecked(Command::FormatRedrawDisplay);
                 return Ok(());
             }
 
@@ -131,7 +131,7 @@ pub fn handle_event(
                 }
                 compiled_regex
             } else {
-                unreachable!();
+                return Ok(());
             };
 
             command_queue.push_back_unchecked(Command::FormatRedrawDisplay);

--- a/src/core/utils/mod.rs
+++ b/src/core/utils/mod.rs
@@ -36,4 +36,16 @@ impl LinesRowMap {
     pub fn get(&self, ln: usize) -> Option<&usize> {
         self.0.get(ln)
     }
+
+    pub(crate) fn row_to_line(&self, row: usize) -> Option<usize> {
+        if self.0.is_empty() {
+            return None;
+        }
+
+        Some(match self.0.binary_search(&row) {
+            Ok(idx) => idx,
+            Err(0) => 0,
+            Err(idx) => idx.saturating_sub(1),
+        })
+    }
 }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -318,7 +318,7 @@ impl Pager {
     #[cfg_attr(docsrs, doc(cfg(feature = "search")))]
     pub fn set_incremental_search_condition(
         &self,
-        cb: Box<dyn Fn(&SearchOpts) -> bool + Send + Sync + 'static>,
+        cb: Box<dyn Fn(&SearchOpts, &str) -> bool + Send + Sync + 'static>,
     ) -> crate::Result {
         self.tx.send(Command::IncrementalSearchCondition(cb))?;
         Ok(())

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -203,33 +203,18 @@ impl Default for Screen {
 // [`PagerState::lines`]: crate::state::PagerState::lines
 
 pub(crate) trait AppendableBuffer {
-    fn append_to_buffer(&mut self, other: &mut Rows);
-    fn extend_buffer<I>(&mut self, other: I)
-    where
-        I: IntoIterator<Item = Row>;
+    fn push_row(&mut self, row: Row);
 }
 
 impl AppendableBuffer for Rows {
-    fn append_to_buffer(&mut self, other: &mut Rows) {
-        self.append(other);
-    }
-    fn extend_buffer<I>(&mut self, other: I)
-    where
-        I: IntoIterator<Item = Row>,
-    {
-        self.extend(other);
+    fn push_row(&mut self, row: Row) {
+        self.push(row);
     }
 }
 
 impl AppendableBuffer for &mut Rows {
-    fn append_to_buffer(&mut self, other: &mut Rows) {
-        self.append(other);
-    }
-    fn extend_buffer<I>(&mut self, other: I)
-    where
-        I: IntoIterator<Item = Row>,
-    {
-        self.extend(other);
+    fn push_row(&mut self, row: Row) {
+        self.push(row);
     }
 }
 
@@ -386,89 +371,68 @@ where
     // Whenever a line is formatted, this will be incremented to te number of rows that the formatted line has occupied
     let mut formatted_row_count = opts.formatted_lines_count;
 
-    {
-        let line_numbers = opts.line_numbers;
-        let cols = opts.cols;
-        let lines_count = opts.lines_count;
-        let line_wrapping = opts.line_wrapping;
+    let (last_idx, last_line_text) = lines.last().copied().unwrap();
+    for (idx, line) in lines.iter().take(lines.len().saturating_sub(1)) {
+        fr.lines_to_row_map.insert(formatted_row_count, true);
+        fr.max_line_length = fr.max_line_length.max(line.len());
+
+        let rows = format_line(
+            line,
+            line_number_digits,
+            opts.lines_count + idx,
+            opts.line_numbers,
+            opts.cols,
+            opts.line_wrapping,
+        );
+
         #[cfg(feature = "search")]
-        let search_term = opts.search_term;
+        let rows = format_search_rows(rows, opts.search_term);
 
-        let rest_lines =
-            lines
-                .iter()
-                .take(lines.len().saturating_sub(1))
-                .flat_map(|(idx, line)| {
-                    let fmt_line = formatted_line(
-                        line,
-                        line_number_digits,
-                        lines_count + idx,
-                        line_numbers,
-                        cols,
-                        line_wrapping,
-                        #[cfg(feature = "search")]
-                        formatted_row_count,
-                        #[cfg(feature = "search")]
-                        &mut fr.append_search_idx,
-                        #[cfg(feature = "search")]
-                        search_term,
-                    );
-                    fr.lines_to_row_map.insert(formatted_row_count, true);
-                    formatted_row_count += fmt_line.len();
-                    if lines.len() > fr.max_line_length {
-                        fr.max_line_length = line.len();
-                    }
+        #[cfg(feature = "search")]
+        {
+            formatted_row_count += collect_rows(
+                &mut opts.buffer,
+                rows,
+                formatted_row_count,
+                &mut fr.append_search_idx,
+            );
+        }
 
-                    fmt_line
-                });
-        opts.buffer.extend_buffer(rest_lines);
-    };
+        #[cfg(not(feature = "search"))]
+        {
+            formatted_row_count += collect_rows(&mut opts.buffer, rows);
+        }
+    }
 
-    let mut last_line = formatted_line(
-        lines.last().unwrap().1,
+    let last_line = format_line(
+        last_line_text,
         line_number_digits,
-        opts.lines_count + to_format_size - 1,
+        opts.lines_count + last_idx,
         opts.line_numbers,
         opts.cols,
         opts.line_wrapping,
-        #[cfg(feature = "search")]
-        formatted_row_count,
-        #[cfg(feature = "search")]
-        &mut fr.append_search_idx,
-        #[cfg(feature = "search")]
-        opts.search_term,
     );
+    #[cfg(feature = "search")]
+    let last_line = format_search_rows(last_line, opts.search_term);
+
+    let last_line_rows = last_line.size_hint().1.unwrap();
+
     fr.lines_to_row_map.insert(formatted_row_count, true);
-    formatted_row_count += last_line.len();
-    if lines.last().unwrap().1.len() > fr.max_line_length {
-        fr.max_line_length = lines.last().unwrap().1.len();
-    }
+    fr.max_line_length = fr.max_line_length.max(last_line_text.len());
 
     #[cfg(feature = "search")]
     {
-        // NOTE: VERY IMPORTANT BLOCK TO GET PROPER SEARCH INDEX
-        // Here is the current scenario: suppose you have text block like this (markers are present to denote where a
-        // new line begins).
-        //
-        // * This is line one row one
-        //   This is line one row two
-        //   This is line one row three
-        // * This is line two row one
-        //   This is line two row two
-        //   This is line two row three
-        //   This is line two row four
-        //
-        // and suppose a match is found at line 1 row 2 and line 2 row 4. So the index generated will be [1, 6].
-        // Let's say this text block is going to be appended to [PagerState::formatted_lines] from index 23.
-        // Now if directly append this generated index to [`PagerState::search_idx`], it will probably be wrong
-        // as these numbers are *relative to current text block*. The actual search index should have been 24, 30.
-        //
-        // To fix this we basically add the number of items in [`PagerState::formatted_lines`].
-        fr.append_search_idx = fr
-            .append_search_idx
-            .iter()
-            .map(|i| opts.formatted_lines_count + i)
-            .collect();
+        formatted_row_count += collect_rows(
+            &mut opts.buffer,
+            last_line,
+            formatted_row_count,
+            &mut fr.append_search_idx,
+        );
+    }
+
+    #[cfg(not(feature = "search"))]
+    {
+        formatted_row_count += collect_rows(&mut opts.buffer, last_line);
     }
 
     // Calculate number of rows which are part of last line and are left unterminated  due to absence of \n
@@ -476,12 +440,137 @@ where
         // If the last line ends with \n, then the line is complete so nothing is left as unterminated
         0
     } else {
-        last_line.len()
+        last_line_rows
     };
-    opts.buffer.append_to_buffer(&mut last_line);
     fr.rows_formatted = formatted_row_count - opts.formatted_lines_count;
 
     fr
+}
+
+pub(crate) fn format_line<'a>(
+    line: Line<'a>,
+    len_line_number: usize,
+    line_number: usize,
+    show_line_numbers: LineNumbers,
+    cols: usize,
+    line_wrapping: bool,
+) -> impl Iterator<Item = String> {
+    assert!(
+        !line.contains('\n'),
+        "Newlines found in appending line {:?}",
+        line
+    );
+    let line_numbers = matches!(
+        show_line_numbers,
+        LineNumbers::Enabled | LineNumbers::AlwaysOn
+    );
+
+    // NOTE: Only relevant when line numbers are active
+    // Padding is the space that the actual line text will be shifted to accommodate for
+    // line numbers. This is equal to:-
+    // LineNumbers::EXTRA_PADDING + len_line_number + 1 (for '.') + 1 (for 1 space)
+    //
+    // We reduce this from the number of available columns as this space cannot be used for
+    // actual line display when wrapping the lines
+    let padding = len_line_number + LineNumbers::EXTRA_PADDING + 1;
+
+    let cols_avail = if line_numbers {
+        cols.saturating_sub(padding + 2)
+    } else {
+        cols
+    };
+
+    // Wrap the line and return an iterator over all the rows
+    let enumerated_rows = if line_wrapping {
+        textwrap::wrap(line, cols_avail)
+    } else {
+        vec![Cow::from(line)]
+    }
+    .into_iter()
+    .enumerate();
+
+    let formatter = move |row: Cow<'_, str>, is_first_row: bool, idx: usize| {
+        format!(
+            "{bold}{number: >len$}{reset} {row}",
+            bold = if cfg!(not(test)) && is_first_row {
+                crossterm::style::Attribute::Bold.to_string()
+            } else {
+                String::new()
+            },
+            number = if is_first_row {
+                (idx + 1).to_string() + "."
+            } else {
+                String::new()
+            },
+            len = padding,
+            reset = if cfg!(not(test)) && is_first_row {
+                crossterm::style::Attribute::Reset.to_string()
+            } else {
+                String::new()
+            },
+            row = row
+        )
+    };
+
+    enumerated_rows.map(move |(i, row)| {
+        if line_numbers && i == 0 {
+            formatter(row, true, line_number)
+        } else if line_numbers {
+            formatter(row, false, 0)
+        } else {
+            row.to_string()
+        }
+    })
+}
+
+#[cfg(feature = "search")]
+pub(crate) fn format_search_rows<'a>(
+    rows: impl Iterator<Item = String> + 'a,
+    search_term: Option<&'a Regex>,
+) -> impl Iterator<Item = (String, bool)> + 'a {
+    rows.map(move |row| {
+        if let Some(st) = search_term {
+            search::highlight_line_matches(&row, st, false)
+        } else {
+            (row, false)
+        }
+    })
+}
+
+#[cfg(feature = "search")]
+fn collect_rows<B, I>(
+    buffer: &mut B,
+    rows: I,
+    formatted_idx: usize,
+    search_idx: &mut BTreeSet<usize>,
+) -> usize
+where
+    B: AppendableBuffer,
+    I: IntoIterator<Item = (String, bool)>,
+{
+    let mut row_count = 0;
+    for (wrap_idx, (row, is_match)) in rows.into_iter().enumerate() {
+        if is_match {
+            search_idx.insert(formatted_idx + wrap_idx);
+        }
+        buffer.push_row(row);
+        row_count = wrap_idx + 1;
+    }
+    row_count
+}
+
+#[cfg(not(feature = "search"))]
+fn collect_rows<B, I>(buffer: &mut B, rows: I) -> usize
+where
+    B: AppendableBuffer,
+    I: IntoIterator<Item = String>,
+{
+    let mut row_count = 0;
+    for row in rows {
+        buffer.push_row(row);
+        row_count += 1;
+    }
+    row_count
 }
 
 /// Formats the given `line`
@@ -510,111 +599,28 @@ pub(crate) fn formatted_line<'a>(
     #[cfg(feature = "search")] search_idx: &mut BTreeSet<usize>,
     #[cfg(feature = "search")] search_term: Option<&regex::Regex>,
 ) -> Rows {
-    assert!(
-        !line.contains('\n'),
-        "Newlines found in appending line {:?}",
-        line
+    let rows = format_line(
+        line,
+        len_line_number,
+        idx,
+        line_numbers,
+        cols,
+        line_wrapping,
     );
-    let line_numbers = matches!(line_numbers, LineNumbers::Enabled | LineNumbers::AlwaysOn);
+    let mut formatted_rows = Vec::with_capacity(256);
 
-    // NOTE: Only relevant when line numbers are active
-    // Padding is the space that the actual line text will be shifted to accommodate for
-    // line numbers. This is equal to:-
-    // LineNumbers::EXTRA_PADDING + len_line_number + 1 (for '.') + 1 (for 1 space)
-    //
-    // We reduce this from the number of available columns as this space cannot be used for
-    // actual line display when wrapping the lines
-    let padding = len_line_number + LineNumbers::EXTRA_PADDING + 1;
-
-    let cols_avail = if line_numbers {
-        cols.saturating_sub(padding + 2)
-    } else {
-        cols
-    };
-
-    // Wrap the line and return an iterator over all the rows
-    let mut enumerated_rows = if line_wrapping {
-        textwrap::wrap(line, cols_avail)
-    } else {
-        vec![Cow::from(line)]
+    #[cfg(feature = "search")]
+    {
+        let rows = format_search_rows(rows, search_term);
+        collect_rows(&mut formatted_rows, rows, formatted_idx, search_idx);
     }
-    .into_iter()
-    .enumerate();
 
-    // highlight the lines with matching search terms
-    // If a match is found, add this line's index to PagerState::search_idx
-    #[cfg_attr(not(feature = "search"), allow(unused_mut))]
-    #[cfg_attr(not(feature = "search"), allow(unused_variables))]
-    let mut handle_search = |row: &mut Cow<'a, str>, wrap_idx: usize| {
-        #[cfg(feature = "search")]
-        if let Some(st) = search_term.as_ref() {
-            let (highlighted_row, is_match) = search::highlight_line_matches(row, st, false);
-            if is_match {
-                *row.to_mut() = highlighted_row;
-                search_idx.insert(formatted_idx + wrap_idx);
-            }
-        }
-    };
-
-    if line_numbers {
-        let mut formatted_rows = Vec::with_capacity(256);
-
-        // Formatter for only when line numbers are active
-        // * If minus is run under test, ascii codes for making the numbers bol is not inserted because they add
-        // extra difficulty while writing tests
-        // * Line number is added only to the first row of a line. This makes a better UI overall
-        let formatter = |row: Cow<'_, str>, is_first_row: bool, idx: usize| {
-            format!(
-                "{bold}{number: >len$}{reset} {row}",
-                bold = if cfg!(not(test)) && is_first_row {
-                    crossterm::style::Attribute::Bold.to_string()
-                } else {
-                    String::new()
-                },
-                number = if is_first_row {
-                    (idx + 1).to_string() + "."
-                } else {
-                    String::new()
-                },
-                len = padding,
-                reset = if cfg!(not(test)) && is_first_row {
-                    crossterm::style::Attribute::Reset.to_string()
-                } else {
-                    String::new()
-                },
-                row = row
-            )
-        };
-
-        // First format the first row separate from other rows, then the subsequent rows and finally join them
-        // This is because only the first row contains the line number and not the subsequent rows
-        let first_row = {
-            #[cfg_attr(not(feature = "search"), allow(unused_mut))]
-            let mut row = enumerated_rows.next().unwrap().1;
-            handle_search(&mut row, 0);
-            formatter(row, true, idx)
-        };
-        formatted_rows.push(first_row);
-
-        #[cfg_attr(not(feature = "search"), allow(unused_mut))]
-        #[cfg_attr(not(feature = "search"), allow(unused_variables))]
-        let rows_left = enumerated_rows.map(|(wrap_idx, mut row)| {
-            handle_search(&mut row, wrap_idx);
-            formatter(row, false, 0)
-        });
-        formatted_rows.extend(rows_left);
-
-        formatted_rows
-    } else {
-        // If line numbers aren't active, simply return the rows with search matches highlighted if search is active
-        #[cfg_attr(not(feature = "search"), allow(unused_variables))]
-        enumerated_rows
-            .map(|(wrap_idx, mut row)| {
-                handle_search(&mut row, wrap_idx);
-                row.to_string()
-            })
-            .collect::<Vec<String>>()
+    #[cfg(not(feature = "search"))]
+    {
+        collect_rows(&mut formatted_rows, rows);
     }
+
+    formatted_rows
 }
 
 pub(crate) fn make_format_lines(

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 #[cfg(feature = "search")]
 use regex::Regex;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 #[cfg(feature = "search")]
 use {crate::search, std::collections::BTreeSet};
@@ -21,6 +21,75 @@ pub type Rows = Vec<String>;
 pub type Line<'a> = &'a str;
 pub type TextBlock<'a> = &'a str;
 pub type OwnedTextBlock = String;
+
+pub(crate) struct FormattedRow<'a> {
+    row: Cow<'a, str>,
+    show_line_numbers: bool,
+    line_number: Option<usize>,
+    padding: usize,
+}
+
+impl<'a> FormattedRow<'a> {
+    fn raw_row(&self) -> &str {
+        &self.row
+    }
+
+    fn fmt_prefix(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.show_line_numbers {
+            return Ok(());
+        }
+
+        match self.line_number {
+            Some(line_number) => {
+                let line_number = line_number + 1;
+                let number_width = minus_core::utils::digits(line_number) + 1;
+                let left_padding = self.padding.saturating_sub(number_width);
+
+                write!(f, "{:left_padding$}", "")?;
+                if cfg!(not(test)) {
+                    write!(f, "{}", crossterm::style::Attribute::Bold)?;
+                }
+                write!(f, "{line_number}.")?;
+                if cfg!(not(test)) {
+                    write!(f, "{}", crossterm::style::Attribute::Reset)?;
+                }
+                f.write_str(" ")
+            }
+            None => write!(f, "{:>width$} ", "", width = self.padding),
+        }
+    }
+}
+
+impl fmt::Display for FormattedRow<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_prefix(f)?;
+        f.write_str(self.raw_row())
+    }
+}
+
+#[cfg(feature = "search")]
+pub(crate) struct SearchFormattedRow<'a, 'b> {
+    row: FormattedRow<'a>,
+    search_term: Option<&'b Regex>,
+    is_match: bool,
+}
+
+#[cfg(feature = "search")]
+impl fmt::Display for SearchFormattedRow<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.row.fmt_prefix(f)?;
+
+        if self.is_match {
+            write!(
+                f,
+                "{}",
+                search::highlight_matches_args(self.row.raw_row(), self.search_term.unwrap(), false)
+            )
+        } else {
+            f.write_str(self.row.raw_row())
+        }
+    }
+}
 
 // ||||||||||||||||||||||||||||||||||||||||||||||
 //  SCREEN TYPE AND ITS REKATED FUNCTIONS
@@ -454,7 +523,7 @@ pub(crate) fn format_line<'a>(
     show_line_numbers: LineNumbers,
     cols: usize,
     line_wrapping: bool,
-) -> impl Iterator<Item = String> {
+) -> impl Iterator<Item = FormattedRow<'a>> {
     assert!(
         !line.contains('\n'),
         "Newlines found in appending line {:?}",
@@ -489,56 +558,40 @@ pub(crate) fn format_line<'a>(
     .into_iter()
     .enumerate();
 
-    let formatter = move |row: Cow<'_, str>, is_first_row: bool, idx: usize| {
-        format!(
-            "{bold}{number: >len$}{reset} {row}",
-            bold = if cfg!(not(test)) && is_first_row {
-                crossterm::style::Attribute::Bold.to_string()
-            } else {
-                String::new()
-            },
-            number = if is_first_row {
-                (idx + 1).to_string() + "."
-            } else {
-                String::new()
-            },
-            len = padding,
-            reset = if cfg!(not(test)) && is_first_row {
-                crossterm::style::Attribute::Reset.to_string()
-            } else {
-                String::new()
-            },
-            row = row
-        )
-    };
-
     enumerated_rows.map(move |(i, row)| {
-        if line_numbers && i == 0 {
-            formatter(row, true, line_number)
-        } else if line_numbers {
-            formatter(row, false, 0)
-        } else {
-            row.to_string()
+        FormattedRow {
+            row,
+            show_line_numbers: line_numbers,
+            line_number: if line_numbers && i == 0 {
+                Some(line_number)
+            } else {
+                None
+            },
+            padding,
         }
     })
 }
 
 #[cfg(feature = "search")]
 pub(crate) fn format_search_rows<'a>(
-    rows: impl Iterator<Item = String> + 'a,
+    rows: impl Iterator<Item = FormattedRow<'a>> + 'a,
     search_term: Option<&'a Regex>,
-) -> impl Iterator<Item = (String, bool)> + 'a {
+) -> impl Iterator<Item = (SearchFormattedRow<'a, 'a>, bool)> + 'a {
     rows.map(move |row| {
-        if let Some(st) = search_term {
-            search::highlight_line_matches(&row, st, false)
-        } else {
-            (row, false)
-        }
+        let is_match = search_term.is_some_and(|st| st.is_match(row.raw_row()));
+        (
+            SearchFormattedRow {
+                row,
+                search_term,
+                is_match,
+            },
+            is_match,
+        )
     })
 }
 
 #[cfg(feature = "search")]
-fn collect_rows<B, I>(
+fn collect_rows<B, I, D>(
     buffer: &mut B,
     rows: I,
     formatted_idx: usize,
@@ -546,28 +599,30 @@ fn collect_rows<B, I>(
 ) -> usize
 where
     B: AppendableBuffer,
-    I: IntoIterator<Item = (String, bool)>,
+    I: IntoIterator<Item = (D, bool)>,
+    D: fmt::Display,
 {
     let mut row_count = 0;
     for (wrap_idx, (row, is_match)) in rows.into_iter().enumerate() {
         if is_match {
             search_idx.insert(formatted_idx + wrap_idx);
         }
-        buffer.push_row(row);
+        buffer.push_row(row.to_string());
         row_count = wrap_idx + 1;
     }
     row_count
 }
 
 #[cfg(not(feature = "search"))]
-fn collect_rows<B, I>(buffer: &mut B, rows: I) -> usize
+fn collect_rows<B, I, D>(buffer: &mut B, rows: I) -> usize
 where
     B: AppendableBuffer,
-    I: IntoIterator<Item = String>,
+    I: IntoIterator<Item = D>,
+    D: fmt::Display,
 {
     let mut row_count = 0;
     for row in rows {
-        buffer.push_row(row);
+        buffer.push_row(row.to_string());
         row_count += 1;
     }
     row_count

--- a/src/search.rs
+++ b/src/search.rs
@@ -16,13 +16,14 @@
 //! and then reuses those results when the search query is confirmed by pressing `Enter`. This
 //! approach eliminates the need to re run the search of text after confirming the query.
 //!
-//! Running Incremental search can be controlled by a function. The function should take
-//! reference to [SearchOpts] as the only argument and return a bool as output. This way we can impose a
-//! condition so that incremental search does not get really resource intensive for really vague queries
-//! This also allows applications can control whether they want incremental search to run.
-//! By default minus uses a default condition where incremental search runs only when length of search
-//! query is greater than 1 and number of screen lines (lines obtained after taking care of wrapping,
-//! mapped to a single row on the terminal) is greater than 5000.
+//! Running Incremental search can be controlled by a function. The function should take reference
+//! to [SearchOpts] and `&str` containing the currently entered query as arguments and return a bool
+//! as output. This way we can impose a condition so that incremental search does not get really
+//! resource intensive for really vague queries This also allows applications can control whether
+//! they want incremental search to run. By default minus uses a default condition where incremental
+//! search runs only when length of search query is greater than 1 and number of screen lines (lines
+//! obtained after taking care of wrapping, mapped to a single row on the terminal) is greater than
+//! 5000.
 //!
 //! Applications can override this condition with the help of
 //! [`Pager::set_incremental_search_condition`](crate::pager::Pager::set_incremental_search_condition) function.
@@ -33,21 +34,21 @@
 //! use minus::{Pager, search::SearchOpts};
 //!
 //! let pager = Pager::new();
-//! pager.set_incremental_search_condition(Box::new(|so: &SearchOpts| so.string.len() > 1)).unwrap();
+//! pager.set_incremental_search_condition(Box::new(|_, line: &str| line.len() > 1)).unwrap();
 //! ```
 //! To completely disable incremental search, set the condition to false
 //! ```
 //! use minus::{Pager, search::SearchOpts};
 //!
 //! let pager = Pager::new();
-//! pager.set_incremental_search_condition(Box::new(|_| false)).unwrap();
+//! pager.set_incremental_search_condition(Box::new(|_, _| false)).unwrap();
 //! ```
 //! Similarly to always run incremental search, set the condition to true
 //! ```
 //! use minus::{Pager, search::SearchOpts};
 //!
 //! let pager = Pager::new();
-//! pager.set_incremental_search_condition(Box::new(|_| true)).unwrap();
+//! pager.set_incremental_search_condition(Box::new(|_, _| true)).unwrap();
 //! ```
 
 use crate::minus_core::utils::{LinesRowMap, display, term};

--- a/src/search.rs
+++ b/src/search.rs
@@ -50,37 +50,34 @@
 //! pager.set_incremental_search_condition(Box::new(|_| true)).unwrap();
 //! ```
 
-#![allow(unused_imports)]
 use crate::minus_core::utils::{LinesRowMap, display, term};
 use crate::screen::Screen;
 use crate::{LineNumbers, PagerState};
-use crate::{error::MinusError, input::HashedEventRegister, screen};
+use crate::{error::MinusError, screen};
 use crossterm::{
-    cursor::{self, MoveTo},
-    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    cursor,
     style::Attribute,
     terminal::{Clear, ClearType},
 };
 use regex::Regex;
+use rustyline::completion::Completer;
+use rustyline::highlight::{CmdKind, Highlighter};
+use rustyline::hint::Hinter;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Context, Editor, Helper, error::ReadlineError};
 use std::collections::BTreeSet;
 use std::{
-    convert::{TryFrom, TryInto},
+    borrow::Cow,
+    convert::TryInto,
     io::Write,
-    sync::LazyLock,
-    time::Duration,
+    sync::{LazyLock, Mutex},
 };
-
-use std::collections::hash_map::RandomState;
 
 static INVERT: LazyLock<String> = LazyLock::new(|| Attribute::Reverse.to_string());
 static NORMAL: LazyLock<String> = LazyLock::new(|| Attribute::NoReverse.to_string());
 static ANSI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new("[\\u001b\\u009b]\\[[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]")
         .unwrap()
-});
-
-static WORD: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"([\w_]+)|([-?~@#!$%^&*()-+={}\[\]:;\\|'/?<>.,"]+)|\W"#).unwrap()
 });
 
 #[derive(Clone, Copy, Debug, Default, Eq)]
@@ -112,29 +109,16 @@ impl PartialEq for SearchMode {
 /// this
 #[allow(clippy::module_name_repetitions)]
 pub struct SearchOpts<'a> {
-    /// A [crossterm Event](Event) on which to respond
-    pub ev: Option<Event>,
-    /// Current string query
-    pub string: String,
-    /// Status of the input prompt. See [InputStatus]
-    pub input_status: InputStatus,
-    /// Specifies the terminal column number that the cursor on at the prompt site.
-    /// It can range between 1 and `string.len() + 1`
-    pub cursor_position: u16,
     /// Direction of search. See [SearchMode].
     pub search_mode: SearchMode,
-    /// Column numbers where each new word start
-    pub word_index: Vec<u16>,
-    /// Search character, either `/` or `?` depending on [SearchMode]
-    pub search_char: char,
     /// Number of rows available in the terminal
     pub rows: u16,
     /// Number of cols available in the terminal
     pub cols: u16,
     /// Options specifically controlling incremental search
     pub incremental_search_options: Option<IncrementalSearchOpts<'a>>,
-    incremental_search_cache: Option<IncrementalSearchCache>,
-    compiled_regex: Option<Regex>,
+    pub(crate) incremental_search_cache: Option<IncrementalSearchCache>,
+    pub(crate) compiled_regex: Option<Regex>,
 }
 
 /// Options to control incremental search
@@ -166,23 +150,9 @@ impl<'a> From<&'a PagerState> for IncrementalSearchOpts<'a> {
 #[allow(clippy::fallible_impl_from)]
 impl<'a> From<&'a PagerState> for SearchOpts<'a> {
     fn from(ps: &'a PagerState) -> Self {
-        let search_char = if ps.search_state.search_mode == SearchMode::Forward {
-            '/'
-        } else if ps.search_state.search_mode == SearchMode::Reverse {
-            '?'
-        } else {
-            unreachable!();
-        };
-
         let incremental_search_options = IncrementalSearchOpts::from(ps);
 
         Self {
-            ev: None,
-            string: String::with_capacity(200),
-            input_status: InputStatus::Active,
-            cursor_position: 1,
-            word_index: Vec::with_capacity(200),
-            search_char,
             rows: ps.rows.try_into().unwrap(),
             cols: ps.cols.try_into().unwrap(),
             incremental_search_options: Some(incremental_search_options),
@@ -190,26 +160,6 @@ impl<'a> From<&'a PagerState> for SearchOpts<'a> {
             compiled_regex: None,
             search_mode: ps.search_state.search_mode,
         }
-    }
-}
-
-/// Status of the search prompt
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum InputStatus {
-    /// Closed due to confirmation of search query using `Enter`
-    Confirmed,
-    /// Closed due to abortion using `Esc`
-    Cancelled,
-    /// Search prompt is open
-    Active,
-}
-
-impl InputStatus {
-    /// Returns true if the input prompt is closed either by confirming the query or by cancelling
-    /// he search
-    #[must_use]
-    pub const fn done(&self) -> bool {
-        matches!(self, Self::Cancelled | Self::Confirmed)
     }
 }
 
@@ -379,11 +329,12 @@ fn incremental_preview(
 fn run_incremental_search<'a, F, O>(
     out: &mut O,
     so: &'a SearchOpts<'a>,
+    line: &'a str,
     incremental_search_condition: F,
 ) -> crate::Result<Option<IncrementalSearchCache>>
 where
     O: Write,
-    F: Fn(&'a SearchOpts) -> bool,
+    F: Fn(&'a SearchOpts, &'a str) -> bool,
 {
     if so.incremental_search_options.is_none() {
         return Ok(None);
@@ -391,7 +342,7 @@ where
     let iso = so.incremental_search_options.as_ref().unwrap();
 
     // Check if we can continue forward with incremental search
-    let should_proceed = so.compiled_regex.is_some() && incremental_search_condition(so);
+    let should_proceed = so.compiled_regex.is_some() && incremental_search_condition(so, line);
 
     // **Screen resetting**:
     // This is an important bit when running incremental search.It reset the terminal screen to
@@ -460,208 +411,76 @@ where
     }))
 }
 
-/// Respond to keyboard events
-///
-/// This souuld be called exactly once for each event by [fetch_input]
-#[allow(clippy::too_many_lines)]
-fn handle_key_press<O, F>(
-    out: &mut O,
-    so: &mut SearchOpts<'_>,
-    incremental_search_condition: F,
-) -> crate::Result
-where
-    O: Write,
-    F: Fn(&SearchOpts<'_>) -> bool,
-{
-    // Bounds between which our cursor can move
-    const FIRST_AVAILABLE_COLUMN: u16 = 1;
-    let last_available_column: u16 = so.string.len().saturating_add(1).try_into().unwrap();
+// HACK: GET the bare `Write` trait to be `Send` + `Sync` without leaving the lock
+struct ThreadSafeWriter<'a>(*mut (dyn Write + 'a));
 
-    // If no event is present, abort
-    if so.ev.is_none() {
-        return Ok(());
+unsafe impl<'a> Send for ThreadSafeWriter<'a> {}
+unsafe impl<'a> Sync for ThreadSafeWriter<'a> {}
+
+impl<'a> Write for ThreadSafeWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        unsafe { (*self.0).write(buf) }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        unsafe { (*self.0).flush() }
+    }
+}
+
+struct SearchHelper<'a> {
+    out: Mutex<ThreadSafeWriter<'a>>,
+    search_opts: Mutex<SearchOpts<'a>>,
+    incremental_search_condition: &'a (dyn Fn(&SearchOpts, &str) -> bool + Send + Sync),
+}
+
+impl<'a> Helper for SearchHelper<'a> {}
+
+impl<'a> Highlighter for SearchHelper<'a> {
+    fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
+        let mut out = self.out.lock().unwrap();
+        let mut so = self.search_opts.lock().unwrap();
+
+        so.compiled_regex = Regex::new(line).ok();
+
+        if let Ok(Some(cache)) =
+            run_incremental_search(&mut *out, &*so, line, self.incremental_search_condition)
+        {
+            so.incremental_search_cache = Some(cache);
+        }
+
+        let _ = term::move_cursor(&mut *out, 0, so.rows, false);
+        let _ = out.flush();
+
+        Cow::Borrowed(line)
     }
 
-    let populate_word_index = |so: &mut SearchOpts<'_>| {
-        so.word_index = WORD
-            .find_iter(&so.string)
-            .map(|c| c.start().saturating_add(1).try_into().unwrap())
-            .collect::<Vec<u16>>();
-    };
-
-    let refresh_display = |out: &mut O, so: &mut SearchOpts<'_>| -> Result<(), MinusError> {
-        // Cache the compiled regex if the regex is valid
-        so.compiled_regex = Regex::new(&so.string).ok();
-
-        // Run incremental search and update the upper mark if incremental search had a successful
-        // run otherwise set it to the initial upper mark
-        so.incremental_search_cache =
-            run_incremental_search(out, so, incremental_search_condition)?;
-
-        // Update prompt
-        term::move_cursor(out, 0, so.rows, false)?;
-        write!(
-            out,
-            "\r{}{}{}",
-            Clear(ClearType::CurrentLine),
-            so.search_char,
-            so.string,
-        )?;
-        Ok(())
-    };
-    match so.ev.as_ref().unwrap() {
-        Event::Key(KeyEvent { kind, .. }) if *kind != KeyEventKind::Press => (),
-        // If Esc is pressed, cancel the search and also make sure that the search query is
-        // ")cleared
-        Event::Key(KeyEvent {
-            code: KeyCode::Esc,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            so.string.clear();
-            so.input_status = InputStatus::Cancelled;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Backspace,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            // On backspace, remove the last character just before the cursor from the so.string
-            // But if we are at very first character, do nothing.
-            if so.cursor_position == FIRST_AVAILABLE_COLUMN {
-                return Ok(());
-            }
-            so.cursor_position = so.cursor_position.saturating_sub(1);
-            so.string
-                .remove(so.cursor_position.saturating_sub(1).into());
-            populate_word_index(so);
-            // Update the line
-            refresh_display(out, so)?;
-            term::move_cursor(out, so.cursor_position, so.rows, false)?;
-            out.flush()?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Delete,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            // On delete, remove the character under the cursor from the so.string
-            // But if we are at the column right after the last character, do nothing.
-            if so.cursor_position >= last_available_column {
-                return Ok(());
-            }
-            so.cursor_position = so.cursor_position.saturating_sub(1);
-            so.string
-                .remove(<u16 as Into<usize>>::into(so.cursor_position));
-            populate_word_index(so);
-            so.cursor_position = so.cursor_position.saturating_add(1);
-            // Update the line
-            refresh_display(out, so)?;
-            term::move_cursor(out, so.cursor_position, so.rows, false)?;
-            out.flush()?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Enter,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            so.input_status = InputStatus::Confirmed;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Left,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            if so.cursor_position == FIRST_AVAILABLE_COLUMN {
-                return Ok(());
-            }
-            so.cursor_position = so.cursor_position.saturating_sub(1);
-            term::move_cursor(out, so.cursor_position, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Left,
-            modifiers: KeyModifiers::CONTROL,
-            ..
-        }) => {
-            // Find the column number where a word starts which is exactly before the current
-            // cursor position
-            // If we can't find any such column, jump to the very first available column
-            so.cursor_position = *so
-                .word_index
-                .iter()
-                .rfind(|c| c < &&so.cursor_position)
-                .unwrap_or(&FIRST_AVAILABLE_COLUMN);
-            term::move_cursor(out, so.cursor_position, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Right,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            if so.cursor_position >= last_available_column {
-                return Ok(());
-            }
-            so.cursor_position = so.cursor_position.saturating_add(1);
-            term::move_cursor(out, so.cursor_position, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Right,
-            modifiers: KeyModifiers::CONTROL,
-            ..
-        }) => {
-            // Find the column number where a word starts which is exactly after the current
-            // cursor position
-            // If we can't find any such column, jump to the very last available column
-            so.cursor_position = *so
-                .word_index
-                .iter()
-                .find(|c| c > &&so.cursor_position)
-                .unwrap_or(&last_available_column);
-            term::move_cursor(out, so.cursor_position, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Home,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            so.cursor_position = 1;
-            term::move_cursor(out, 1, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::End,
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            so.cursor_position = so.string.len().saturating_add(1).try_into().unwrap();
-            term::move_cursor(out, so.cursor_position, so.rows, true)?;
-        }
-        Event::Key(KeyEvent {
-            code: KeyCode::Char(c),
-            modifiers: KeyModifiers::NONE,
-            ..
-        }) => {
-            // For any character key, without a modifier, insert it into so.string before
-            // current cursor position and update the line
-            so.string
-                .insert(so.cursor_position.saturating_sub(1).into(), *c);
-            populate_word_index(so);
-            refresh_display(out, so)?;
-            so.cursor_position = so.cursor_position.saturating_add(1);
-            term::move_cursor(out, so.cursor_position, so.rows, false)?;
-            out.flush()?;
-        }
-        _ => return Ok(()),
+    fn highlight_char(&self, _line: &str, _pos: usize, _forced: CmdKind) -> bool {
+        true
     }
-    Ok(())
+}
+
+impl<'a> Validator for SearchHelper<'a> {
+    fn validate(&self, _ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
+        Ok(ValidationResult::Valid(None))
+    }
+    fn validate_while_typing(&self) -> bool {
+        false
+    }
+}
+
+impl<'a> Hinter for SearchHelper<'a> {
+    type Hint = String;
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        None
+    }
+}
+
+impl<'a> Completer for SearchHelper<'a> {
+    type Candidate = String;
 }
 
 /// Fetch the search query
 ///
-/// The function will change the prompt to `/` for Forward search or `?` for Reverse search.
-/// Next it fetches and handles all events from the terminal screen until [SearchOpts::input_status] isn't
-/// set to either [InputStatus::Cancelled] or [InputStatus::Confirmed] by pressing `Esc` or
-/// `Enter` respectively.
-/// Finally we return
+/// Uses rustyline for prompt input.
 #[cfg(feature = "search")]
 pub(crate) fn fetch_input(
     out: &mut impl std::io::Write,
@@ -669,61 +488,76 @@ pub(crate) fn fetch_input(
 ) -> Result<FetchInputResult, MinusError> {
     // Set the search character to show at column 0
     let search_char = if ps.search_state.search_mode == SearchMode::Forward {
-        '/'
+        "/"
     } else {
-        '?'
+        "?"
     };
 
     // Initial setup
     // - Place the cursor at the beginning of prompt line
     // - Clear the prompt
-    // - Write the search character and
     // - Show the cursor
     term::move_cursor(out, 0, ps.rows.try_into().unwrap(), false)?;
-    write!(
-        out,
-        "{}{}{}",
-        Clear(ClearType::CurrentLine),
-        search_char,
-        cursor::Show
-    )?;
+    write!(out, "{}{}", Clear(ClearType::CurrentLine), cursor::Show)?;
+    crossterm::execute!(out, crossterm::event::DisableMouseCapture)?;
     out.flush()?;
 
-    let mut search_opts = SearchOpts::from(ps);
+    let mut readline = Editor::<SearchHelper<'_>, _>::new().unwrap();
+    let search_opts = SearchOpts::from(ps);
+    let writer_ptr = out as *mut dyn std::io::Write;
+    readline.set_helper(Some(SearchHelper {
+        out: Mutex::new(ThreadSafeWriter(writer_ptr)),
+        search_opts: Mutex::new(search_opts),
+        incremental_search_condition: &*ps.search_state.incremental_search_condition,
+    }));
 
-    // Fetch events from the terminal and handle them
-    loop {
-        if event::poll(Duration::from_millis(100)).map_err(|e| MinusError::HandleEvent(e.into()))? {
-            let ev = event::read().map_err(|e| MinusError::HandleEvent(e.into()))?;
-            search_opts.ev = Some(ev);
-            handle_key_press(
-                out,
-                &mut search_opts,
-                &ps.search_state.incremental_search_condition,
-            )?;
-            search_opts.ev = None;
-        }
-        if search_opts.input_status.done() {
-            break;
-        }
-    }
+    let prompt = readline.readline(search_char);
+
     // Teardown: almost opposite of setup
-    term::move_cursor(out, 0, ps.rows.try_into().unwrap(), false)?;
-    write!(out, "{}{}", Clear(ClearType::CurrentLine), cursor::Hide)?;
-    out.flush()?;
+    let helper = readline.helper_mut().unwrap();
+    let mut out_lock = helper.out.lock().unwrap();
+    term::move_cursor(&mut *out_lock, 0, ps.rows.try_into().unwrap(), false)?;
+    write!(
+        &mut *out_lock,
+        "{}{}",
+        Clear(ClearType::CurrentLine),
+        cursor::Hide
+    )?;
+    crossterm::execute!(&mut *out_lock, crossterm::event::EnableMouseCapture)?;
+    out_lock.flush()?;
+    drop(out_lock);
 
-    let fetch_input_result = match search_opts.input_status {
-        InputStatus::Active => unreachable!(),
-        InputStatus::Cancelled => FetchInputResult::new_empty(),
-        // When the query is confirmed, return the actual query along with everything that is valid
-        // in the cache
-        InputStatus::Confirmed => FetchInputResult {
-            string: search_opts.string,
-            incremental_search_result: search_opts.incremental_search_cache,
-            compiled_regex: search_opts.compiled_regex,
-        },
-    };
-    Ok(fetch_input_result)
+    match prompt {
+        Ok(str) => {
+            let mut so = helper.search_opts.lock().unwrap();
+            Ok(FetchInputResult {
+                compiled_regex: so.compiled_regex.take(),
+                incremental_search_result: so.incremental_search_cache.take(),
+                string: str,
+            })
+        }
+        Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => {
+            let mut out_lock = helper.out.lock().unwrap();
+            let so = helper.search_opts.lock().unwrap();
+            if let Some(iso) = &so.incremental_search_options {
+                let _ = display::write_text_checked(
+                    &mut *out_lock,
+                    &iso.screen.formatted_lines,
+                    iso.initial_upper_mark,
+                    so.rows.into(),
+                    so.cols.into(),
+                    iso.screen.line_wrapping,
+                    iso.initial_left_mark,
+                    iso.line_numbers,
+                    iso.screen.line_count(),
+                );
+            }
+            Ok(FetchInputResult::new_empty())
+        }
+        Err(ReadlineError::Io(e)) => Err(MinusError::from(e)),
+        Err(ReadlineError::Errno(_)) | Err(ReadlineError::Signal(_)) => todo!(),
+        Err(_) => Ok(FetchInputResult::new_empty()),
+    }
 }
 
 /// Highlights the search match
@@ -865,292 +699,6 @@ pub(crate) fn next_nth_match(
 
 #[cfg(test)]
 mod tests {
-    mod input_handling {
-        use crate::{
-            SearchMode,
-            search::{InputStatus, SearchOpts, handle_key_press},
-        };
-        use crossterm::{
-            cursor::MoveTo,
-            event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
-            terminal::{Clear, ClearType},
-        };
-        use std::{convert::TryInto, io::Write};
-
-        fn new_search_opts(sm: SearchMode) -> SearchOpts<'static> {
-            let search_char = match sm {
-                SearchMode::Forward => '/',
-                SearchMode::Reverse => '?',
-                SearchMode::Unknown => unreachable!(),
-            };
-
-            SearchOpts {
-                ev: None,
-                string: String::with_capacity(200),
-                input_status: InputStatus::Active,
-                cursor_position: 1,
-                word_index: Vec::with_capacity(200),
-                search_char,
-                rows: 25,
-                cols: 100,
-                incremental_search_options: None,
-                incremental_search_cache: None,
-                compiled_regex: None,
-                search_mode: sm,
-            }
-        }
-
-        const fn make_event_from_keycode(kc: KeyCode) -> Event {
-            Event::Key(KeyEvent {
-                code: kc,
-                kind: KeyEventKind::Press,
-                modifiers: KeyModifiers::NONE,
-                state: KeyEventState::NONE,
-            })
-        }
-
-        fn pretest_setup_forward_search() -> (SearchOpts<'static>, Vec<u8>, u16, &'static str) {
-            const QUERY_STRING: &str = "this is@complex-text_search?query"; // length = 33
-            #[allow(clippy::cast_possible_truncation)]
-            let last_movable_column: u16 = (QUERY_STRING.len() as u16) + 1; // 34
-
-            let mut search_opts = new_search_opts(SearchMode::Forward);
-            let mut out = Vec::with_capacity(1500);
-
-            for c in QUERY_STRING.chars() {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Char(c)));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            }
-            assert_eq!(search_opts.cursor_position, last_movable_column);
-            (search_opts, out, last_movable_column, QUERY_STRING)
-        }
-
-        #[test]
-        fn input_sequential_text() {
-            let mut search_opts = new_search_opts(SearchMode::Forward);
-            let mut out = Vec::with_capacity(1500);
-            for (i, c) in "text search matches".chars().enumerate() {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Char(c)));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.input_status, InputStatus::Active);
-                assert_eq!(search_opts.cursor_position as usize, i + 2);
-            }
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Enter));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.word_index, vec![1, 5, 6, 12, 13]);
-            assert_eq!(&search_opts.string, "text search matches");
-            assert_eq!(search_opts.input_status, InputStatus::Confirmed);
-        }
-
-        #[test]
-        fn input_complex_sequential_text() {
-            let mut search_opts = new_search_opts(SearchMode::Forward);
-            let mut out = Vec::with_capacity(1500);
-            for (i, c) in "this is@complex-text_search?query".chars().enumerate() {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Char(c)));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.input_status, InputStatus::Active);
-                assert_eq!(search_opts.cursor_position as usize, i + 2);
-            }
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Enter));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.word_index, vec![1, 5, 6, 8, 9, 16, 17, 28, 29]);
-            assert_eq!(&search_opts.string, "this is@complex-text_search?query");
-            assert_eq!(search_opts.input_status, InputStatus::Confirmed);
-        }
-
-        #[test]
-        fn home_end_keys() {
-            // Setup
-            let (mut search_opts, mut out, last_movable_column, _) = pretest_setup_forward_search();
-
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Home));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position as usize, 1);
-
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::End));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position, last_movable_column);
-        }
-
-        #[test]
-        fn basic_left_arrow_movement() {
-            const FIRST_MOVABLE_COLUMN: u16 = 1;
-            let (mut search_opts, mut out, last_movable_column, _) = pretest_setup_forward_search();
-            let query_string_length = last_movable_column - 1;
-
-            // We are currently at the very next column to the last char
-
-            // Check functionality of left arrow key
-            // Pressing left arrow moves the cursor towards the beginning of string until it
-            // reaches the first char after which pressing it further would not have any effect
-            for i in (FIRST_MOVABLE_COLUMN..=query_string_length).rev() {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Left));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.cursor_position, i);
-            }
-            // Pressing Left arrow any more will not make any effect
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Left));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position, FIRST_MOVABLE_COLUMN);
-        }
-
-        #[test]
-        fn basic_right_arrow_movement() {
-            // Setup
-            let (mut search_opts, mut out, last_movable_column, _) = pretest_setup_forward_search();
-            // Go to the 1st char
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Home));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-
-            // Check functionality of right arrow key
-            // Pressing right arrow moves the cursor towards the end of string until it
-            // reaches the very next column to the last char after which pressing it further would not have any effect
-            for i in 2..=last_movable_column {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Right));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.cursor_position, i);
-            }
-            // Pressing right arrow any more will not make any effect
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Right));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position, last_movable_column);
-        }
-
-        #[test]
-        fn right_jump_by_word() {
-            const JUMP_COLUMNS: [u16; 10] = [1, 5, 6, 8, 9, 16, 17, 28, 29, LAST_MOVABLE_COLUMN];
-            // Setup
-            let (mut search_opts, mut out, _last_movable_column, _) =
-                pretest_setup_forward_search();
-            // LAST_MOVABLE_COLUMN = _last_movable_column = 34
-            #[allow(clippy::items_after_statements)]
-            const LAST_MOVABLE_COLUMN: u16 = 34;
-
-            // Go to the 1st char
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Home));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-
-            let ev = Event::Key(KeyEvent {
-                code: KeyCode::Right,
-                kind: KeyEventKind::Press,
-                modifiers: KeyModifiers::CONTROL,
-                state: KeyEventState::NONE,
-            });
-
-            // Jump right word by word
-            for i in &JUMP_COLUMNS[1..] {
-                search_opts.ev = Some(ev.clone());
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.cursor_position, *i);
-            }
-            // Pressing ctrl+right will not do anything any keep the cursor at the very next column
-            // to the last char
-            search_opts.ev = Some(ev);
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position, LAST_MOVABLE_COLUMN);
-        }
-
-        #[test]
-        fn left_jump_by_word() {
-            const JUMP_COLUMNS: [u16; 10] = [1, 5, 6, 8, 9, 16, 17, 28, 29, LAST_MOVABLE_COLUMN];
-            // Setup
-            let (mut search_opts, mut out, _last_movable_column, _) =
-                pretest_setup_forward_search();
-            // LAST_MOVABLE_COLUMN = _last_movable_column = 34
-            #[allow(clippy::items_after_statements)]
-            const LAST_MOVABLE_COLUMN: u16 = 34;
-
-            // We are currently at the very next column to the last char
-            let ev = Event::Key(KeyEvent {
-                code: KeyCode::Left,
-                kind: KeyEventKind::Press,
-                modifiers: KeyModifiers::CONTROL,
-                state: KeyEventState::NONE,
-            });
-
-            // Jump right word by word
-            for i in (JUMP_COLUMNS[..(JUMP_COLUMNS.len() - 1)]).iter().rev() {
-                search_opts.ev = Some(ev.clone());
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-                assert_eq!(search_opts.cursor_position, *i);
-            }
-            // Pressing ctrl+left will not do anything and keep the cursor at the very first column
-            search_opts.ev = Some(ev);
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.cursor_position, JUMP_COLUMNS[0]);
-        }
-
-        #[test]
-        fn esc_key() {
-            let (mut search_opts, mut out, _, _) = pretest_setup_forward_search();
-
-            search_opts.ev = Some(make_event_from_keycode(KeyCode::Esc));
-            handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            assert_eq!(search_opts.input_status, InputStatus::Cancelled);
-        }
-
-        #[test]
-        fn forward_sequential_text_input_screen_data() {
-            let (search_opts, out, _last_movable_column, query_string) =
-                pretest_setup_forward_search();
-
-            let mut result_out = Vec::with_capacity(1500);
-
-            // Try to recreate the behaviour of handle_key_press when new char is entered
-            let mut string = String::with_capacity(query_string.len());
-            let mut cursor_position: u16 = 1;
-            for c in query_string.chars() {
-                string.push(c);
-                cursor_position = cursor_position.saturating_add(1);
-                write!(
-                    result_out,
-                    "{move_to_prompt}\r{clear_line}/{string}{move_to_position}",
-                    move_to_prompt = MoveTo(0, search_opts.rows),
-                    clear_line = Clear(ClearType::CurrentLine),
-                    move_to_position = MoveTo(cursor_position, search_opts.rows),
-                )
-                .unwrap();
-            }
-            assert_eq!(out, result_out);
-        }
-
-        #[test]
-        fn backward_sequential_text_input_screen_data() {
-            const QUERY_STRING: &str = "this is@complex-text_search?query"; // length = 33
-            #[allow(clippy::cast_possible_truncation)]
-            const LAST_MOVABLE_COLUMN: u16 = (QUERY_STRING.len() as u16) + 1; // 34
-
-            let mut search_opts = new_search_opts(SearchMode::Reverse);
-            let mut out = Vec::with_capacity(1500);
-
-            for c in QUERY_STRING.chars() {
-                search_opts.ev = Some(make_event_from_keycode(KeyCode::Char(c)));
-                handle_key_press(&mut out, &mut search_opts, |_| false).unwrap();
-            }
-            assert_eq!(search_opts.cursor_position, LAST_MOVABLE_COLUMN);
-
-            let mut result_out = Vec::with_capacity(1500);
-
-            // Try to recreate the behaviour of handle_key_press when new char is entered
-            let mut string = String::with_capacity(QUERY_STRING.len());
-            let mut cursor_position: u16 = 1;
-            for c in QUERY_STRING.chars() {
-                string.push(c);
-                cursor_position = cursor_position.saturating_add(1);
-                write!(
-                    result_out,
-                    "{move_to_prompt}\r{clear_line}?{string}{move_to_position}",
-                    move_to_prompt = MoveTo(0, search_opts.rows),
-                    clear_line = Clear(ClearType::CurrentLine),
-                    move_to_position = MoveTo(cursor_position, search_opts.rows),
-                )
-                .unwrap();
-            }
-            assert_eq!(out, result_out);
-        }
-    }
-
     #[test]
     fn test_next_match() {
         // A sample index for mocking actual search index matches

--- a/src/search.rs
+++ b/src/search.rs
@@ -70,6 +70,7 @@ use std::collections::BTreeSet;
 use std::{
     borrow::Cow,
     convert::TryInto,
+    fmt,
     io::Write,
     sync::{LazyLock, Mutex},
 };
@@ -561,21 +562,54 @@ pub(crate) fn fetch_input(
     }
 }
 
-/// Highlights the search match
-///
-/// The first return value returns the line that has all the search matches highlighted
-/// The second tells whether a search match was actually found
-pub(crate) fn highlight_line_matches(
-    line: &str,
-    query: &regex::Regex,
+pub(crate) struct HighlightMatchesArgs<'a, 'b> {
+    line: &'a str,
+    query: &'b Regex,
     accurate: bool,
-) -> (String, bool) {
-    // Remove all ansi escapes so we can look through it as if it had none
+    is_match: bool,
+}
+
+impl fmt::Display for HighlightMatchesArgs<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.is_match {
+            return f.write_str(self.line);
+        }
+
+        if !ANSI_REGEX.is_match(self.line) {
+            let mut last = 0;
+            for matched in self.query.find_iter(self.line) {
+                f.write_str(&self.line[last..matched.start()])?;
+                write!(f, "{}{}{}", *INVERT, matched.as_str(), *NORMAL)?;
+                last = matched.end();
+            }
+            return f.write_str(&self.line[last..]);
+        }
+
+        f.write_str(&highlight_line_matches_ansi(self.line, self.query, self.accurate))
+    }
+}
+
+pub(crate) fn highlight_matches_args<'a, 'b>(
+    line: &'a str,
+    query: &'b Regex,
+    accurate: bool,
+) -> HighlightMatchesArgs<'a, 'b> {
+    let stripped_str = ANSI_REGEX.replace_all(line, "");
+    let is_match = query.is_match(&stripped_str);
+    HighlightMatchesArgs {
+        line,
+        query,
+        accurate,
+        is_match,
+    }
+}
+
+fn highlight_line_matches_ansi(line: &str, query: &regex::Regex, accurate: bool) -> String {
     let stripped_str = ANSI_REGEX.replace_all(line, "");
 
     // if it doesn't match, don't even try. Just return.
     if !query.is_match(&stripped_str) {
-        return (line.to_string(), false);
+        return line.to_string();
     }
 
     // sum_width is used to calculate the total width of the ansi escapes
@@ -650,7 +684,21 @@ pub(crate) fn highlight_line_matches(
         inserted_escs_len += esc.1.len();
     }
 
-    (inverted, true)
+    inverted
+}
+
+/// Highlights the search match
+///
+/// The first return value returns the line that has all the search matches highlighted
+/// The second tells whether a search match was actually found
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn highlight_line_matches(
+    line: &str,
+    query: &regex::Regex,
+    accurate: bool,
+) -> (String, bool) {
+    let highlighted = highlight_matches_args(line, query, accurate);
+    (highlighted.to_string(), highlighted.is_match)
 }
 
 /// Return a index of an element from `search_idx` that will contain a search match and

--- a/src/search.rs
+++ b/src/search.rs
@@ -51,7 +51,7 @@
 //! ```
 
 #![allow(unused_imports)]
-use crate::minus_core::utils::{display, term};
+use crate::minus_core::utils::{LinesRowMap, display, term};
 use crate::screen::Screen;
 use crate::{LineNumbers, PagerState};
 use crate::{error::MinusError, input::HashedEventRegister, screen};
@@ -138,9 +138,6 @@ pub struct SearchOpts<'a> {
 }
 
 /// Options to control incremental search
-///
-/// NOTE: `text` and `initial_formatted_lines` are experimental in this context and are subject to
-/// change. Use them at your own risk.
 pub struct IncrementalSearchOpts<'a> {
     /// Current status of line numbering
     pub line_numbers: LineNumbers,
@@ -148,6 +145,8 @@ pub struct IncrementalSearchOpts<'a> {
     pub initial_upper_mark: usize,
     /// Reference to [PagerState::screen]
     pub screen: &'a Screen,
+    /// Cached map from logical lines to formatted rows.
+    pub lines_to_row_map: &'a LinesRowMap,
     /// Value of [PagerState::upper_mark] before starting of search prompt
     pub initial_left_mark: usize,
 }
@@ -158,6 +157,7 @@ impl<'a> From<&'a PagerState> for IncrementalSearchOpts<'a> {
             line_numbers: ps.line_numbers,
             initial_upper_mark: ps.upper_mark,
             screen: &ps.screen,
+            lines_to_row_map: &ps.lines_to_row_map,
             initial_left_mark: ps.left_mark,
         }
     }
@@ -237,17 +237,135 @@ impl FetchInputResult {
 
 /// A cache for storing all the new data obtained by running incremental search
 pub(crate) struct IncrementalSearchCache {
-    /// Lines to be displayed with highlighted search matches
-    pub(crate) formatted_lines: Vec<String>,
-    /// Index from `search_idx` where a search match after current upper mark may be found
-    /// NOTE: There is no guarantee that this will stay within the bounds of `search_idx`
-    pub(crate) search_mark: usize,
     /// Indices of formatted_lines where search matches have been found
     pub(crate) search_idx: BTreeSet<usize>,
     /// Index of the line from which to display the text.
     /// This will be set to the index of line which is after the current upper mark and will
     /// have a search match for sure
     pub(crate) upper_mark: usize,
+}
+
+fn line_matches_query(line: &str, query: &Regex) -> bool {
+    let stripped = ANSI_REGEX.replace_all(line, "");
+    query.is_match(stripped.as_ref())
+}
+
+fn incremental_preview(
+    iso: &IncrementalSearchOpts<'_>,
+    query: &Regex,
+    cols: usize,
+    rows: usize,
+) -> Option<(Vec<String>, usize)> {
+    fn preview_line(
+        iso: &IncrementalSearchOpts<'_>,
+        query: &Regex,
+        cols: usize,
+        line_number_digits: usize,
+        line_idx: usize,
+        line: &str,
+        visible_lines: &mut Vec<String>,
+        upper_mark: &mut Option<usize>,
+        writable_rows: usize,
+        wrapped: bool,
+    ) -> Option<()> {
+        // Skip all lines that don't have any match
+        if upper_mark.is_none() && !line_matches_query(line, query) {
+            return Some(());
+        }
+
+        let row_start = *iso.lines_to_row_map.get(line_idx).unwrap_or(&0);
+        let mut search_idx = BTreeSet::new();
+        let mut formatted_rows = screen::formatted_line(
+            line,
+            line_number_digits,
+            line_idx,
+            iso.line_numbers,
+            cols,
+            iso.screen.line_wrapping,
+            row_start,
+            &mut search_idx,
+            Some(query),
+        );
+
+        if upper_mark.is_none() {
+            let match_row = *search_idx
+                .iter()
+                .find(|idx| wrapped || **idx >= iso.initial_upper_mark)?;
+            let skip_rows = match_row.saturating_sub(row_start);
+            *upper_mark = Some(match_row);
+            visible_lines.extend(formatted_rows.drain(skip_rows..));
+        } else {
+            visible_lines.append(&mut formatted_rows);
+        }
+
+        if visible_lines.len() >= writable_rows {
+            visible_lines.truncate(writable_rows);
+        }
+
+        Some(())
+    }
+
+    let writable_rows = rows.saturating_sub(1);
+    if writable_rows == 0 {
+        return None;
+    }
+
+    let start_line_idx = iso.lines_to_row_map.row_to_line(iso.initial_upper_mark)?;
+    let line_number_digits = crate::minus_core::utils::digits(iso.screen.line_count());
+    let mut visible_lines = Vec::with_capacity(writable_rows);
+    let mut upper_mark = None;
+
+    for (line_idx, line) in iso
+        .screen
+        .orig_text
+        .lines()
+        .enumerate()
+        .skip(start_line_idx)
+    {
+        preview_line(
+            iso,
+            query,
+            cols,
+            line_number_digits,
+            line_idx,
+            line,
+            &mut visible_lines,
+            &mut upper_mark,
+            writable_rows,
+            false,
+        )?;
+        if visible_lines.len() >= writable_rows {
+            break;
+        }
+    }
+
+    if upper_mark.is_none() {
+        for (line_idx, line) in iso
+            .screen
+            .orig_text
+            .lines()
+            .enumerate()
+            .take(start_line_idx)
+        {
+            preview_line(
+                iso,
+                query,
+                cols,
+                line_number_digits,
+                line_idx,
+                line,
+                &mut visible_lines,
+                &mut upper_mark,
+                writable_rows,
+                true,
+            )?;
+            if visible_lines.len() >= writable_rows {
+                break;
+            }
+        }
+    }
+
+    upper_mark.map(|upper_mark| (visible_lines, upper_mark))
 }
 
 /// Runs the incremental search
@@ -310,46 +428,35 @@ where
         return Ok(None);
     }
 
-    // Format the text with search highlights and get the index of the element in
-    // format_result.append_search_idx which is after the current upper mark
-    //
-    // PERF: Check if this can be futhur optimized
-    let (buffer, format_result) = screen::make_format_lines(
-        &iso.screen.orig_text,
-        iso.line_numbers,
-        so.cols.into(),
-        iso.screen.line_wrapping,
-        so.compiled_regex.as_ref(),
-    );
-    let position_of_next_match =
-        next_nth_match(&format_result.append_search_idx, iso.initial_upper_mark, 0);
-    // Get the upper mark. If we can't find one, reset the display
-    let upper_mark;
-    if let Some(pnm) = position_of_next_match {
-        upper_mark = *format_result.append_search_idx.iter().nth(pnm).unwrap();
-        // Draw the incrementally searched lines from upper mark
-        display::write_text_checked(
-            out,
-            &buffer,
-            upper_mark,
-            so.rows.into(),
-            so.cols.into(),
-            iso.screen.line_wrapping,
-            iso.initial_left_mark,
-            iso.line_numbers,
-            iso.screen.line_count(),
-        )?;
-    } else {
+    let query = so.compiled_regex.as_ref().unwrap();
+
+    let Some((visible_lines, upper_mark)) =
+        incremental_preview(iso, query, so.cols.into(), so.rows.into())
+    else {
         reset_screen(out, so)?;
         return Ok(None);
-    }
+    };
+
+    // Draw the incrementally searched lines from upper mark
+    display::write_text_checked(
+        out,
+        &visible_lines,
+        0,
+        so.rows.into(),
+        so.cols.into(),
+        iso.screen.line_wrapping,
+        iso.initial_left_mark,
+        iso.line_numbers,
+        iso.screen.line_count(),
+    )?;
+
     // Return the results obtained by running incremental search so that they can be stored as a
     // cache.
+    let mut search_idx = BTreeSet::new();
+    search_idx.insert(upper_mark);
     Ok(Some(IncrementalSearchCache {
-        formatted_lines: buffer,
-        search_mark: position_of_next_match.unwrap(),
         upper_mark,
-        search_idx: format_result.append_search_idx,
+        search_idx,
     }))
 }
 
@@ -720,8 +827,7 @@ pub(crate) fn highlight_line_matches(
 /// `Some(3)` which is index of 34.
 ///
 /// If `jump` causes the index to overflow the length of the `search_idx`, the function will set it
-/// to the index of last element in `search_idx`.Also if search_idx is empty, this will simply
-/// return None.
+/// to wrap to the start of `search_idx`. Also if search_idx is empty, this will simply return None.
 ///
 /// Setting `jump` equal to 0 causes a slight change in behaviour: it will also return the index of
 /// element if that element is equal to the current upper mark. In the above example lets say that
@@ -738,33 +844,21 @@ pub(crate) fn next_nth_match(
     }
 
     // Find the index of the match that's exactly after the upper_mark.
-    // One we find that, we add n-1 to it to get the next nth match after upper_mark
-    let mut position_of_next_match;
-    if let Some(nearest_idx) = search_idx.iter().position(|i| {
+    // If there isn't one, wrap to the first match in the file.
+    let nearest_idx = search_idx.iter().position(|i| {
         if jump == 0 {
             *i >= upper_mark
         } else {
             *i > upper_mark
         }
-    }) {
-        // This ensures that index doesn't get off-by-one in case of jump = 0
-        if jump == 0 {
-            position_of_next_match = nearest_idx;
-        } else {
-            position_of_next_match = nearest_idx.saturating_add(jump).saturating_sub(1);
-        }
+    });
 
-        // If position_of_next_match is goes beyond the length of search_idx
-        // set it to the length of search_idx -1 which corresponds to the index of
-        // last match
-        if position_of_next_match > search_idx.len().saturating_sub(1) {
-            position_of_next_match = search_idx.len().saturating_sub(1);
-        }
+    let start_idx = nearest_idx.unwrap_or(0);
+    let position_of_next_match = if jump == 0 {
+        start_idx
     } else {
-        // If there's no match at all simply set it to the length of search_idx -1 which
-        // corresponds to the index of last match
-        position_of_next_match = search_idx.len().saturating_sub(1);
-    }
+        start_idx.saturating_add(jump).saturating_sub(1) % search_idx.len()
+    };
 
     Some(position_of_next_match)
 }
@@ -1070,6 +1164,16 @@ mod tests {
             assert_eq!(next_upper_mark, *v);
             upper_mark = next_upper_mark;
         }
+    }
+
+    #[test]
+    fn test_next_match_wraps_to_top() {
+        let search_idx = std::collections::BTreeSet::from([2, 10, 15, 17, 50]);
+
+        assert_eq!(super::next_nth_match(&search_idx, 60, 1), Some(0));
+        assert_eq!(super::next_nth_match(&search_idx, 60, 3), Some(2));
+        assert_eq!(super::next_nth_match(&search_idx, 50, 1), Some(0));
+        assert_eq!(super::next_nth_match(&search_idx, 50, 0), Some(4));
     }
 
     #[allow(clippy::trivial_regex)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -51,14 +51,15 @@ pub struct SearchState {
     ///
     /// If the function returns a `false`, the incremental search is cancelled.
     pub(crate) incremental_search_condition:
-        Box<dyn Fn(&SearchOpts) -> bool + Send + Sync + 'static>,
+        Box<dyn Fn(&SearchOpts, &str) -> bool + Send + Sync + 'static>,
 }
 
 #[cfg(feature = "search")]
 impl Default for SearchState {
     fn default() -> Self {
-        let incremental_search_condition = Box::new(|so: &SearchOpts| {
-            so.string.len() > 1
+        let incremental_search_condition = Box::new(|so: &SearchOpts, line: &str| {
+            line.len() > 1
+                // TODO: Do perf tests after [pr:#159] and check if this can be lifted off
                 && so
                     .incremental_search_options
                     .as_ref()

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 //! Contains types that hold run-time information of the pager.
 
 #[cfg(feature = "search")]
-use crate::search::{SearchMode, SearchOpts};
+use crate::search::{SearchMode, SearchOpts, next_nth_match};
 
 use crate::{
     ExitStrategy, LineNumbers,
@@ -254,6 +254,8 @@ impl PagerState {
         #[cfg(feature = "search")]
         {
             self.search_state.search_idx = format_result.append_search_idx;
+            self.search_state.search_mark =
+                next_nth_match(&self.search_state.search_idx, self.upper_mark, 0).unwrap_or(0);
         }
         self.screen.formatted_lines = buffer;
         self.lines_to_row_map = format_result.lines_to_row_map;


### PR DESCRIPTION
The `formatted_line()` function, which is the central function for formatting the lines in the terminal, was a monolith. It dealt with text wrapping, search highlighting, and generation of search indices.

This PR breaks it down to smaller functions, each dealing with one step of the entire formatting chain. The functions are called in a chain with help from `Iterator`s and a few custom structs holding the data to achieve the same formatting style.

This design allowed us to eliminate **ALMOST ALL** allocations in the formatting pipeline.

The only time when we allocate is when assembling the final formatted lines. This can also be optimized to reuse the already available `String` buffers rather than allocating new ones when possible.